### PR TITLE
set timeout to 1s to avoid memory leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ import (
     "time"
 ) 
 for {
-    // timeout value won't be set too large or waste lots of memory
+    // timeout value won't be set too large, otherwise it may waste lots of memory
     ev, _ := streamer.GetEventTimeout(time.Second * 1)
     // Dump event
     ev.Dump(os.Stdout)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ for {
     // Dump event
     ev.Dump(os.Stdout)
 }
+
+// or use timeout use GetEventTimeout but you should deal with the timeout exception
+import (
+    "time"
+) 
+for {
+    // timeout value won't be set too large or waste lots of memory
+    ev, _ := streamer.GetEventTimeout(time.Second * 1)
+    // Dump event
+    ev.Dump(os.Stdout)
+}
 ```
 
 The output looks:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ for {
     ev.Dump(os.Stdout)
 }
 
-// or use timeout use GetEventTimeout but you should deal with the timeout exception
+//or use timeout with GetEventTimeout, and you should deal with the timeout exception 
 import (
     "time"
 ) 

--- a/replication/binlogstreamer.go
+++ b/replication/binlogstreamer.go
@@ -18,11 +18,20 @@ type BinlogStreamer struct {
 }
 
 func (s *BinlogStreamer) GetEvent() (*BinlogEvent, error) {
-	// we use a very very long timeout here
-	return s.GetEventTimeout(time.Second * 1)
+	if s.err != nil {
+		return nil, ErrNeedSyncAgain
+	}
+
+	select {
+	case c := <-s.ch:
+		return c, nil
+	case s.err = <-s.ech:
+		return nil, s.err
+	}
 }
 
 // if timeout, ErrGetEventTimeout will returns
+// timeout value won't be set too large or waste lots of memory
 func (s *BinlogStreamer) GetEventTimeout(d time.Duration) (*BinlogEvent, error) {
 	if s.err != nil {
 		return nil, ErrNeedSyncAgain

--- a/replication/binlogstreamer.go
+++ b/replication/binlogstreamer.go
@@ -19,7 +19,7 @@ type BinlogStreamer struct {
 
 func (s *BinlogStreamer) GetEvent() (*BinlogEvent, error) {
 	// we use a very very long timeout here
-	return s.GetEventTimeout(time.Second * 3600 * 24 * 30)
+	return s.GetEventTimeout(time.Second * 1)
 }
 
 // if timeout, ErrGetEventTimeout will returns

--- a/replication/binlogstreamer.go
+++ b/replication/binlogstreamer.go
@@ -31,7 +31,7 @@ func (s *BinlogStreamer) GetEvent() (*BinlogEvent, error) {
 }
 
 // if timeout, ErrGetEventTimeout will returns
-// timeout value won't be set too large or waste lots of memory
+// timeout value won't be set too large, otherwise it may waste lots of memory
 func (s *BinlogStreamer) GetEventTimeout(d time.Duration) (*BinlogEvent, error) {
 	if s.err != nil {
 		return nil, ErrNeedSyncAgain


### PR DESCRIPTION
I use replication, when use GetEvent to sync from master, the memory usage grow rapidly. the function 
GetEventTimeout use select to get Events from master and use time.After to set timeout, but the two chennel in different goroutine, when the sync channel return, the time.After channel continue to run, so the memory can't be released.

set timeout to 1s， make sure not used too much memory, after 1s, all used memory by time.After will be
collect by garbage collector