### PR TITLE
Implemented getters to retrieve event and error channels

### DIFF
--- a/replication/binlogstreamer.go
+++ b/replication/binlogstreamer.go
@@ -18,6 +18,14 @@ type BinlogStreamer struct {
 	err error
 }
 
+func (s *BinlogStreamer) GetEventChannel() chan *BinlogEvent {
+	return s.ch
+}
+
+func (s *BinlogStreamer) GetErrorChannel() chan error {
+	return s.ech
+}
+
 func (s *BinlogStreamer) GetEvent() (*BinlogEvent, error) {
 	if s.err != nil {
 		return nil, ErrNeedSyncAgain


### PR DESCRIPTION
This change will allow to process replication events (or errors) alongside with messages from other channels within the same `select {}`.