### PR TITLE
Return u/int8, u/int16, u/int32 (sign-extend Int24), float32, float64 for interface{} as appropriate

### DIFF
--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -103,43 +103,43 @@ func (t *mysqlTestSuite) TestMysqlGTIDContain(c *check.C) {
 }
 
 func (t *mysqlTestSuite) TestMysqlParseBinaryInt8(c *check.C) {
-	i64 := ParseBinaryInt8([]byte{128})
-	c.Assert(i64, check.Equals, int64(-128))
+	i8 := ParseBinaryInt8([]byte{128})
+	c.Assert(i8, check.Equals, int8(-128))
 }
 
 func (t *mysqlTestSuite) TestMysqlParseBinaryUint8(c *check.C) {
-	u64 := ParseBinaryUint8([]byte{128})
-	c.Assert(u64, check.Equals, uint64(128))
+	u8 := ParseBinaryUint8([]byte{128})
+	c.Assert(u8, check.Equals, uint8(128))
 }
 
 func (t *mysqlTestSuite) TestMysqlParseBinaryInt16(c *check.C) {
-	i64 := ParseBinaryInt16([]byte{1, 128})
-	c.Assert(i64, check.Equals, int64(-128*256 + 1))
+	i16 := ParseBinaryInt16([]byte{1, 128})
+	c.Assert(i16, check.Equals, int16(-128*256 + 1))
 }
 
 func (t *mysqlTestSuite) TestMysqlParseBinaryUint16(c *check.C) {
-	u64 := ParseBinaryUint16([]byte{1, 128})
-	c.Assert(u64, check.Equals, uint64(128*256 + 1))
+	u16 := ParseBinaryUint16([]byte{1, 128})
+	c.Assert(u16, check.Equals, uint16(128*256 + 1))
 }
 
 func (t *mysqlTestSuite) TestMysqlParseBinaryInt24(c *check.C) {
-	i64 := ParseBinaryInt24([]byte{1, 2, 128})
-	c.Assert(i64, check.Equals, int64(-128*65536 + 2*256 + 1))
+	i32 := ParseBinaryInt24([]byte{1, 2, 128})
+	c.Assert(i32, check.Equals, int32(-128*65536 + 2*256 + 1))
 }
 
 func (t *mysqlTestSuite) TestMysqlParseBinaryUint24(c *check.C) {
-	u64 := ParseBinaryUint24([]byte{1, 2, 128})
-	c.Assert(u64, check.Equals, uint64(128*65536 + 2*256 + 1))
+	u32 := ParseBinaryUint24([]byte{1, 2, 128})
+	c.Assert(u32, check.Equals, uint32(128*65536 + 2*256 + 1))
 }
 
 func (t *mysqlTestSuite) TestMysqlParseBinaryInt32(c *check.C) {
-	i64 := ParseBinaryInt32([]byte{1, 2, 3, 128})
-	c.Assert(i64, check.Equals, int64(-128*16777216 + 3*65536 + 2*256 + 1))
+	i32 := ParseBinaryInt32([]byte{1, 2, 3, 128})
+	c.Assert(i32, check.Equals, int32(-128*16777216 + 3*65536 + 2*256 + 1))
 }
 
 func (t *mysqlTestSuite) TestMysqlParseBinaryUint32(c *check.C) {
-	u64 := ParseBinaryUint32([]byte{1, 2, 3, 128})
-	c.Assert(u64, check.Equals, uint64(128*16777216 + 3*65536 + 2*256 + 1))
+	u32 := ParseBinaryUint32([]byte{1, 2, 3, 128})
+	c.Assert(u32, check.Equals, uint32(128*16777216 + 3*65536 + 2*256 + 1))
 }
 
 func (t *mysqlTestSuite) TestMysqlParseBinaryInt64(c *check.C) {

--- a/mysql/parse_binary.go
+++ b/mysql/parse_binary.go
@@ -2,38 +2,39 @@ package mysql
 
 import (
 	"encoding/binary"
+	"math"
 )
 
-func ParseBinaryInt8(data []byte) int64 {
-	return int64(int8(data[0]))
+func ParseBinaryInt8(data []byte) int8 {
+	return int8(data[0])
 }
-func ParseBinaryUint8(data []byte) uint64 {
-	return uint64((data[0]))
-}
-
-func ParseBinaryInt16(data []byte) int64 {
-	return int64(int16(binary.LittleEndian.Uint16(data)))
-}
-func ParseBinaryUint16(data []byte) uint64 {
-	return uint64(binary.LittleEndian.Uint16(data))
+func ParseBinaryUint8(data []byte) uint8 {
+	return data[0]
 }
 
-func ParseBinaryInt24(data []byte) int64 {
+func ParseBinaryInt16(data []byte) int16 {
+	return int16(binary.LittleEndian.Uint16(data))
+}
+func ParseBinaryUint16(data []byte) uint16 {
+	return binary.LittleEndian.Uint16(data)
+}
+
+func ParseBinaryInt24(data []byte) int32 {
 	u32 := uint32(ParseBinaryUint24(data))
 	if u32&0x00800000 != 0 {
 		u32 |= 0xFF000000
 	}
-	return int64(int32(u32))
+	return int32(u32)
 }
-func ParseBinaryUint24(data []byte) uint64 {
-	return uint64(uint32(data[0]) + uint32(data[1])<<8 + uint32(data[2])<<16)
+func ParseBinaryUint24(data []byte) uint32 {
+	return uint32(data[0]) | uint32(data[1])<<8 | uint32(data[2])<<16
 }
 
-func ParseBinaryInt32(data []byte) int64 {
-	return int64(int32(binary.LittleEndian.Uint32(data)))
+func ParseBinaryInt32(data []byte) int32 {
+	return int32(binary.LittleEndian.Uint32(data))
 }
-func ParseBinaryUint32(data []byte) uint64 {
-	return uint64(binary.LittleEndian.Uint32(data))
+func ParseBinaryUint32(data []byte) uint32 {
+	return binary.LittleEndian.Uint32(data)
 }
 
 func ParseBinaryInt64(data []byte) int64 {
@@ -41,4 +42,12 @@ func ParseBinaryInt64(data []byte) int64 {
 }
 func ParseBinaryUint64(data []byte) uint64 {
 	return binary.LittleEndian.Uint64(data)
+}
+
+func ParseBinaryFloat32(data []byte) float32 {
+	return math.Float32frombits(binary.LittleEndian.Uint32(data))
+}
+
+func ParseBinaryFloat64(data []byte) float64 {
+	return math.Float64frombits(binary.LittleEndian.Uint64(data))
 }

--- a/mysql/resultset.go
+++ b/mysql/resultset.go
@@ -1,8 +1,6 @@
 package mysql
 
 import (
-	"encoding/binary"
-	"math"
 	"strconv"
 
 	"github.com/juju/errors"
@@ -138,12 +136,12 @@ func (p RowData) ParseBinary(f []*Field) ([]interface{}, error) {
 			continue
 
 		case MYSQL_TYPE_FLOAT:
-			data[i] = float64(math.Float32frombits(binary.LittleEndian.Uint32(p[pos : pos+4])))
+			data[i] = ParseBinaryFloat32(p[pos : pos+4])
 			pos += 4
 			continue
 
 		case MYSQL_TYPE_DOUBLE:
-			data[i] = math.Float64frombits(binary.LittleEndian.Uint64(p[pos : pos+8]))
+			data[i] = ParseBinaryFloat64(p[pos : pos+4])
 			pos += 8
 			continue
 

--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"math"
 	"strconv"
 	"time"
 
@@ -361,10 +360,10 @@ func (e *RowsEvent) decodeValue(data []byte, tp byte, meta uint16) (v interface{
 		v, n, err = decodeDecimal(data, int(prec), int(scale))
 	case MYSQL_TYPE_FLOAT:
 		n = 4
-		v = float64(math.Float32frombits(binary.LittleEndian.Uint32(data)))
+		v = ParseBinaryFloat32(data)
 	case MYSQL_TYPE_DOUBLE:
 		n = 8
-		v = math.Float64frombits(binary.LittleEndian.Uint64(data))
+		v = ParseBinaryFloat64(data)
 	case MYSQL_TYPE_BIT:
 		nbits := ((meta >> 8) * 8) + (meta & 0xFF)
 		n = int(nbits+7) / 8


### PR DESCRIPTION
Related to Issue #26 the previously merged PR maintains the same return types always int64 for integral and float64 for floats.

This PR will return variable width and also the unsigned versions of types. This is somewhat of a breaking change, so consider if this seems better to you. It means that users will have to check for float32 as well as int8, uint8, ... int64, uint64 when interface{} is returned. The plus is that there's less chance of getting the wrong value. In particular for replication/row_event.go since there's no 'unsigned' meta info, signed is always returned. So an int32 for a value like 0x80000000 cast to uint32 will mean the right thing. Without this PR an int64 returned for a MYSQL 32-bit LONG with value 0x0000000080000000 will return 0xFFFFFFFF80000000 (with sign extension) and cast to uint64 will not be the intended value. Cast to uint32 is, but then user must remember to downcast width for unsigned.

Hope this is all clear. If very concerned with backward compatibility, perhaps a mode setting?