### PR TITLE
Add HandleStmtClose Handler interface method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 var
 bin
+.idea

--- a/server/command.go
+++ b/server/command.go
@@ -22,6 +22,9 @@ type Handler interface {
 	//handle COM_STMT_EXECUTE, context is the previous one set in prepare
 	//query is the statement prepare query, and args is the params for this statement
 	HandleStmtExecute(context interface{}, query string, args []interface{}) (*Result, error)
+	//handle COM_STMT_CLOSE, context is the previous one set in prepare
+	//this handler has no response
+	HandleStmtClose(context interface{}) (error)
 }
 
 func (c *Conn) HandleCommand() error {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -108,6 +108,10 @@ func (h *testHandler) HandleStmtPrepare(sql string) (params int, columns int, ct
 	return params, columns, nil, err
 }
 
+func (h *testHandler) HandleStmtClose(context interface{}) error {
+	return nil
+}
+
 func (h *testHandler) HandleStmtExecute(ctx interface{}, query string, args []interface{}) (*mysql.Result, error) {
 	return h.handleQuery(query, true)
 }

--- a/server/stmt.go
+++ b/server/stmt.go
@@ -348,6 +348,15 @@ func (c *Conn) handleStmtClose(data []byte) error {
 
 	id := binary.LittleEndian.Uint32(data[0:4])
 
+	stmt, ok := c.stmts[id]
+	if !ok {
+		return nil
+	}
+
+	if err := c.h.HandleStmtClose(stmt.Context); err != nil {
+		return err
+	}
+
 	delete(c.stmts, id)
 
 	return nil


### PR DESCRIPTION
I'm add HandleStmtClose method to Handler interface. This method is useful for better handling prepared statements lifetime, otherwise, is not possible make complete mysql proxy