### PR TITLE
Length for MYSQL_TYPE_SET is in bytes, not bits

### DIFF
--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -436,10 +436,10 @@ func (e *RowsEvent) decodeValue(data []byte, tp byte, meta uint16) (v interface{
 			err = fmt.Errorf("Unknown ENUM packlen=%d", l)
 		}
 	case MYSQL_TYPE_SET:
-		nbits := meta & 0xFF
-		n = int(nbits+7) / 8
+		n = int(meta & 0xFF)
+		nbits := n * 8
 
-		v, err = decodeBit(data, int(nbits), n)
+		v, err = decodeBit(data, nbits, n)
 	case MYSQL_TYPE_BLOB:
 		switch meta {
 		case 1:


### PR DESCRIPTION
This confuses the parser and causes a panic.  
https://github.com/mysql/mysql-server/blob/5.7/sql/log_event.cc#L2242

```
SELECT IF(data_type = 'SET', 'yes', 'no') is_set_column, COUNT(*) FROM information_schema.columns GROUP BY 1;
+---------------+----------+
| is_set_column | COUNT(*) |
+---------------+----------+
| no            |    12785 |
| yes           |        1 |
+---------------+----------+

```