### PR TITLE
replication: clear table map when end of the statement.

### DIFF
--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -191,6 +191,9 @@ func (e *TableMapEvent) Dump(w io.Writer) {
 	fmt.Fprintln(w)
 }
 
+// RowsEventStmtEndFlag is set in the end of the statement.
+const RowsEventStmtEndFlag = 0x01
+
 type RowsEvent struct {
 	//0, 1, 2
 	Version int


### PR DESCRIPTION
Because now we support retry, we may retry syncing after getting a TableMapEvent, so the next sync will first get a RotateEvent which clears all table map cache, and then the following RowsEvent parsing will fail. 

@qiuyesuifeng 
