### PR TITLE
error in server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ import (
     "net"
 )
 
-l, _ := net.Listen("127.0.0.1:4000")
+l, _ := net.Listen("tcp", "127.0.0.1:4000")
 
 c, _ := l.Accept()
 


### PR DESCRIPTION
In server example, function 'net.Listen("127.0.0.1:4000")'  lack the first parameter netProto