### PR TITLE
typed Timestamp2

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -13,15 +13,16 @@ import (
 )
 
 const (
-	TYPE_NUMBER    = iota + 1 //tinyint, smallint, mediumint, int, bigint, year
-	TYPE_FLOAT                //float, double
-	TYPE_ENUM                 //enum
-	TYPE_SET                  //set
-	TYPE_STRING               //other
-	TYPE_DATETIME             //datetime
-	TYPE_TIMESTAMP            //timestamp
-	TYPE_DATE                 //date
-	TYPE_TIME                 //time
+	TYPE_NUMBER    = iota + 1 // tinyint, smallint, mediumint, int, bigint, year
+	TYPE_FLOAT                // float, double
+	TYPE_ENUM                 // enum
+	TYPE_SET                  // set
+	TYPE_STRING               // other
+	TYPE_DATETIME             // datetime
+	TYPE_TIMESTAMP            // timestamp
+	TYPE_DATE                 // date
+	TYPE_TIME                 // time
+	TYPE_BIT                  // bit
 )
 
 type TableColumn struct {
@@ -87,6 +88,8 @@ func (ta *Table) AddColumn(name string, columnType string, extra string) {
 		ta.Columns[index].Type = TYPE_TIME
 	} else if "date" == columnType {
 		ta.Columns[index].Type = TYPE_DATE
+	} else if strings.HasPrefix(columnType, "bit") {
+		ta.Columns[index].Type = TYPE_BIT
 	} else {
 		ta.Columns[index].Type = TYPE_STRING
 	}


### PR DESCRIPTION
`decodeTimestamp2` only returns a string when the column value was `0000-00-00 00:00:00`. Otherwise -- when it is a "real" timestamp value, the function returns the `time.Time` type.

This allows us to retain the metadata associated with the value, i.e. timezone.
It also allows us to easily recognize a timestamp value where previously the `string` type would obscure the real column type.