### PR TITLE
configurable timestamp decoding behavior

### DIFF
--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -15,6 +15,8 @@ import (
 	"github.com/siddontang/go/hack"
 )
 
+var DecodeTimestamp2AsTime bool = false
+
 type TableMapEvent struct {
 	tableIDSize int
 
@@ -395,7 +397,11 @@ func (e *RowsEvent) decodeValue(data []byte, tp byte, meta uint16) (v interface{
 		t := binary.LittleEndian.Uint32(data)
 		v = time.Unix(int64(t), 0)
 	case MYSQL_TYPE_TIMESTAMP2:
-		v, n, err = decodeTimestamp2(data, meta)
+		if DecodeTimestamp2AsTime {
+			v, n, err = decodeTimestamp2AsTime(data, meta)
+		} else {
+			v, n, err = decodeTimestamp2(data, meta)
+		}
 	case MYSQL_TYPE_DATETIME:
 		n = 8
 		i64 := binary.LittleEndian.Uint64(data)
@@ -605,7 +611,29 @@ func decodeBit(data []byte, nbits int, length int) (value int64, err error) {
 	return
 }
 
-func decodeTimestamp2(data []byte, dec uint16) (interface{}, int, error) {
+func decodeTimestamp2(data []byte, dec uint16) (string, int, error) {
+	//get timestamp binary length
+	n := int(4 + (dec+1)/2)
+	sec := int64(binary.BigEndian.Uint32(data[0:4]))
+	usec := int64(0)
+	switch dec {
+	case 1, 2:
+		usec = int64(data[4]) * 10000
+	case 3, 4:
+		usec = int64(binary.BigEndian.Uint16(data[4:])) * 100
+	case 5, 6:
+		usec = int64(BFixedLengthInt(data[4:7]))
+	}
+
+	if sec == 0 {
+		return "0000-00-00 00:00:00", n, nil
+	}
+
+	t := time.Unix(sec, usec*1000)
+	return t.Format(TimeFormat), n, nil
+}
+
+func decodeTimestamp2AsTime(data []byte, dec uint16) (interface{}, int, error) {
 	//get timestamp binary length
 	n := int(4 + (dec+1)/2)
 	sec := int64(binary.BigEndian.Uint32(data[0:4]))

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -13,15 +13,16 @@ import (
 )
 
 const (
-	TYPE_NUMBER    = iota + 1 //tinyint, smallint, mediumint, int, bigint, year
-	TYPE_FLOAT                //float, double
-	TYPE_ENUM                 //enum
-	TYPE_SET                  //set
-	TYPE_STRING               //other
-	TYPE_DATETIME             //datetime
-	TYPE_TIMESTAMP            //timestamp
-	TYPE_DATE                 //date
-	TYPE_TIME                 //time
+	TYPE_NUMBER    = iota + 1 // tinyint, smallint, mediumint, int, bigint, year
+	TYPE_FLOAT                // float, double
+	TYPE_ENUM                 // enum
+	TYPE_SET                  // set
+	TYPE_STRING               // other
+	TYPE_DATETIME             // datetime
+	TYPE_TIMESTAMP            // timestamp
+	TYPE_DATE                 // date
+	TYPE_TIME                 // time
+	TYPE_BIT                  // bit
 )
 
 type TableColumn struct {
@@ -87,6 +88,8 @@ func (ta *Table) AddColumn(name string, columnType string, extra string) {
 		ta.Columns[index].Type = TYPE_TIME
 	} else if "date" == columnType {
 		ta.Columns[index].Type = TYPE_DATE
+	} else if strings.HasPrefix(columnType, "bit") {
+		ta.Columns[index].Type = TYPE_BIT
 	} else {
 		ta.Columns[index].Type = TYPE_STRING
 	}


### PR DESCRIPTION
The global, visible variable `DecodeTimestamp2AsTime` controls whether `timestamp2` is decoded as string (default, backwards compatibility) or as `time.Time`, where possible.
