### PR TITLE
dont update master if FormatDescriptionEvent

### DIFF
--- a/canal/sync.go
+++ b/canal/sync.go
@@ -59,6 +59,8 @@ func (c *Canal) startSyncBinlog() error {
 			}
 		case *replication.TableMapEvent:
 			continue
+		case *replication.FormatDescriptionEvent:
+			continue
 		default:
 		}
 


### PR DESCRIPTION
If event is FormatDescriptionEvent, then`ev.Header.LogPos` is always 0. We should not update master in that case.