### PR TITLE
support TLS/SSL authentication to the database

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,8 +1,10 @@
 package client
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
+	"strings"
 	"testing"
 
 	. "github.com/pingcap/check"
@@ -74,6 +76,23 @@ func (s *clientTestSuite) testConn_CreateTable(c *C) {
 func (s *clientTestSuite) TestConn_Ping(c *C) {
 	err := s.c.Ping()
 	c.Assert(err, IsNil)
+}
+
+func (s *clientTestSuite) TestConn_TLS(c *C) {
+	// Verify that the provided tls.Config is used when attempting to connect to mysql.
+	// An empty tls.Config will result in a connection error.
+	addr := fmt.Sprintf("%s:%d", *testHost, *testPort)
+	_, err := Connect(addr, *testUser, *testPassword, *testDB, func(c *Conn) {
+		c.TLSConfig = &tls.Config{}
+	})
+	if err == nil {
+		c.Fatal("expected error")
+	}
+
+	expected := "either ServerName or InsecureSkipVerify must be specified in the tls.Config"
+	if !strings.Contains(err.Error(), expected) {
+		c.Fatal("expected '%s' to contain '%s'", err.Error(), expected)
+	}
 }
 
 func (s *clientTestSuite) TestConn_Insert(c *C) {

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -1,6 +1,7 @@
 package replication
 
 import (
+	"crypto/tls"
 	"encoding/binary"
 	"fmt"
 	"os"
@@ -44,6 +45,9 @@ type BinlogSyncerConfig struct {
 
 	// RawModeEanbled is for not parsing binlog event.
 	RawModeEanbled bool
+
+	// If not nil, use the provided tls.Config to connect to the database using TLS/SSL.
+	TLSConfig *tls.Config
 }
 
 // BinlogSyncer syncs binlog event from server.
@@ -129,7 +133,9 @@ func (b *BinlogSyncer) registerSlave() error {
 
 	log.Infof("register slave for master server %s:%d", b.cfg.Host, b.cfg.Port)
 	var err error
-	b.c, err = client.Connect(fmt.Sprintf("%s:%d", b.cfg.Host, b.cfg.Port), b.cfg.User, b.cfg.Password, "")
+	b.c, err = client.Connect(fmt.Sprintf("%s:%d", b.cfg.Host, b.cfg.Port), b.cfg.User, b.cfg.Password, "", func(c *client.Conn) {
+		c.TLSConfig = b.cfg.TLSConfig
+	})
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
This commit updates mysql client authentication to (optionally) support
TLS/SSL connections to the database. To activate, provide tls.Config
when calling client.Connect.

Changes to client/auth.go were copied from the official go-sql-driver.
https://github.com/go-sql-driver/mysql/blob/master/packets.go#L226