### PR TITLE
log unkonw stream header instead quit

### DIFF
--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -529,8 +529,8 @@ func (b *BinlogSyncer) onStream(s *BinlogStreamer) {
 			log.Info("receive EOF packet, retry ReadPacket")
 			continue
 		default:
-			s.closeWithError(fmt.Errorf("invalid stream header %c", data[0]))
-			return
+			log.Warningf("invalid stream header %c", data[0])
+			continue
 		}
 	}
 }

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -529,7 +529,7 @@ func (b *BinlogSyncer) onStream(s *BinlogStreamer) {
 			log.Info("receive EOF packet, retry ReadPacket")
 			continue
 		default:
-			log.Warningf("invalid stream header %c", data[0])
+			log.Errorf("invalid stream header %c", data[0])
 			continue
 		}
 	}


### PR DESCRIPTION
I need  run [go-mysql-elasticsearch](https://github.com/siddontang/go-mysql-elasticsearch) as a daemon service, but I find some time the sync stoped. Below is the log:

`2017/01/17 12:51:08 binlogstreamer.go:47: [error] close sync with err: invalid stream header þ`
`2017/01/17 12:51:08 canal.go:151: [error] canal start sync binlog err: invalid stream header þ`

I can't find out what cause canal stoped, but can we log it instead stop it? 


