### PR TITLE
replication: support geometry

### DIFF
--- a/replication/replication_test.go
+++ b/replication/replication_test.go
@@ -211,6 +211,23 @@ func (t *testSyncerSuite) testSync(c *C, s *BinlogStreamer) {
 		for _, query := range tbls {
 			t.testExecute(c, query)
 		}
+
+		// If MySQL supports JSON, it must supports GEOMETRY.
+		t.testExecute(c, "DROP TABLE IF EXISTS test_geo")
+
+		str = `CREATE TABLE test_geo (g GEOMETRY)`
+		_, err = t.c.Execute(str)
+		c.Assert(err, IsNil)
+
+		tbls = []string{
+			`INSERT INTO test_geo VALUES (POINT(1, 1))`,
+			`INSERT INTO test_geo VALUES (LINESTRING(POINT(0,0), POINT(1,1), POINT(2,2)))`,
+			// TODO: add more geometry tests
+		}
+
+		for _, query := range tbls {
+			t.testExecute(c, query)
+		}
 	}
 
 	t.wg.Wait()


### PR DESCRIPTION
refer #109 

Hi @eLco @shlomi-noach 

Now I just support decode the geometry type to a bytes, you must decode to the real bytes (Point, LineString, etc...) by yourself.

Seem that the bytes format is SRID(4 tyes) + WKB, E.g, a hex string "000000000101000000000000000000F03F000000000000F03F" is for "POINT(1, 1)", First 4 bytes "00000000" is for SRID and latter is for WKB, you can use some existing go lib to parse it or use the MySQL function like "GeoFromWKB".