### PR TITLE
Canal: Clear table cache  when the table structure changed

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -36,6 +36,9 @@ type Canal struct {
 	rsLock     sync.Mutex
 	rsHandlers []RowsEventHandler
 
+	masterInfoLock    sync.RWMutex
+	masterInfoHandler MasterInfoHandler
+
 	connLock sync.Mutex
 	conn     *client.Conn
 
@@ -129,11 +132,17 @@ func (c *Canal) prepareDumper() error {
 	return nil
 }
 
-func (c *Canal) Start() error {
+func (c *Canal) Start() <-chan struct{} {
 	c.wg.Add(1)
-	go c.run()
+	go func() {
+		err := c.run()
+		if err != nil {
+			log.Errorf("Canal.run return error:%v\n", err)
+		}
+		c.Close()
+	}()
 
-	return nil
+	return c.quit
 }
 
 func (c *Canal) run() error {
@@ -172,8 +181,6 @@ func (c *Canal) Close() {
 
 	c.closed.Set(true)
 
-	close(c.quit)
-
 	c.connLock.Lock()
 	c.conn.Close()
 	c.conn = nil
@@ -187,6 +194,9 @@ func (c *Canal) Close() {
 	c.master.Close()
 
 	c.wg.Wait()
+
+	//
+	close(c.quit)
 }
 
 func (c *Canal) WaitDumpDone() <-chan struct{} {
@@ -312,4 +322,12 @@ func (c *Canal) Execute(cmd string, args ...interface{}) (rr *mysql.Result, err 
 
 func (c *Canal) SyncedPosition() mysql.Position {
 	return c.master.Pos()
+}
+
+// SetStartPosition set start sync binlog Pos
+// notice: this func must be called before Canal.Start
+func (c *Canal) SetStartPosition(binlogName string, pos uint32) error {
+	c.master.Update(binlogName, pos)
+	_, err := c.master.Save(true)
+	return err
 }

--- a/canal/canal.go
+++ b/canal/canal.go
@@ -66,7 +66,7 @@ func NewCanal(cfg *Config) (*Canal, error) {
 	} else if len(c.master.Addr) != 0 && c.master.Addr != c.cfg.Addr {
 		log.Infof("MySQL addr %s in old master.info, but new %s, reset", c.master.Addr, c.cfg.Addr)
 		// may use another MySQL, reset
-		c.master = &masterInfo{}
+		c.master = &masterInfo{name: c.masterInfoPath()}
 	}
 
 	c.master.Addr = c.cfg.Addr

--- a/canal/canal.go
+++ b/canal/canal.go
@@ -215,6 +215,14 @@ func (c *Canal) GetTable(db string, table string) (*schema.Table, error) {
 	return t, nil
 }
 
+// ClearTableCache clear table cache
+func (c *Canal) ClearTableCache(db []byte, table []byte) {
+	key := fmt.Sprintf("%s.%s", db, table)
+	c.tableLock.Lock()
+	delete(c.tables, key)
+	c.tableLock.Unlock()
+}
+
 // Check MySQL binlog row image, must be in FULL, MINIMAL, NOBLOB
 func (c *Canal) CheckBinlogRowImage(image string) error {
 	// need to check MySQL binlog row image? full, minimal or noblob?

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -7,6 +7,8 @@ import (
 
 	"regexp"
 
+	"sync"
+
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/siddontang/go-mysql/mysql"
@@ -15,6 +17,9 @@ import (
 
 var (
 	expAlterTable = regexp.MustCompile("^ALTER TABLE\\s.*?`([^`\\.]+?)`\\s.*")
+
+	skipedSchemaLock sync.Mutex
+	skipedSchemaList []string
 )
 
 func (c *Canal) startSyncBinlog() error {
@@ -29,6 +34,7 @@ func (c *Canal) startSyncBinlog() error {
 
 	timeout := time.Second
 	forceSavePos := false
+	posSaved := false
 	for {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		ev, err := s.GetEvent(ctx)
@@ -85,10 +91,41 @@ func (c *Canal) startSyncBinlog() error {
 		}
 
 		c.master.Update(pos.Name, pos.Pos)
-		c.master.Save(forceSavePos)
+		posSaved, err = c.master.Save(forceSavePos)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if posSaved {
+			if h := c.getMasterInfoHandler(); h != nil {
+				h.SavePos(pos.Name, pos.Pos)
+			}
+		}
 	}
 
 	return nil
+}
+
+func (c *Canal) isSkipedSchema(schema string) bool {
+	// fixed: if db not in dump list , skip it.
+	if c.cfg.Dump.TableDB != "" && c.cfg.Dump.TableDB != schema {
+		skipedSchemaLock.Lock()
+		found := false
+		for _, v := range skipedSchemaList {
+			if v == schema {
+				found = true
+				break
+			}
+		}
+		if !found {
+			skipedSchemaList = append(skipedSchemaList, schema)
+		}
+		skipedSchemaLock.Unlock()
+		if !found {
+			log.Infof("database != config.Dump.TableDB(%s != %s), skiped...\n", schema, c.cfg.Dump.TableDB)
+		}
+		return true
+	}
+	return false
 }
 
 func (c *Canal) handleRowsEvent(e *replication.BinlogEvent) error {
@@ -97,6 +134,10 @@ func (c *Canal) handleRowsEvent(e *replication.BinlogEvent) error {
 	// Caveat: table may be altered at runtime.
 	schema := string(ev.Table.Schema)
 	table := string(ev.Table.Table)
+
+	if c.isSkipedSchema(schema) {
+		return nil
+	}
 
 	t, err := c.GetTable(schema, table)
 	if err != nil {

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -5,7 +5,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"bytes"
 	"regexp"
 
 	"github.com/juju/errors"
@@ -15,8 +14,7 @@ import (
 )
 
 var (
-	bSchemaTableSep = []byte("`.`")
-	expAlterTable   = regexp.MustCompile("^ALTER TABLE\\s`(.*?)`\\s.*")
+	expAlterTable = regexp.MustCompile("^ALTER TABLE\\s.*?`([^`\\.]+?)`\\s.*")
 )
 
 func (c *Canal) startSyncBinlog() error {
@@ -75,9 +73,6 @@ func (c *Canal) startSyncBinlog() error {
 		case *replication.QueryEvent:
 			// handle alert table query
 			if mb := expAlterTable.FindSubmatch(e.Query); mb != nil {
-				if bytes.Contains(mb[1], bSchemaTableSep) {
-					mb[1] = bytes.Split(mb[1], bSchemaTableSep)[1]
-				}
 				c.ClearTableCache(e.Schema, mb[1])
 				log.Infof("table structure changed, clear table cache: %s.%s\n", e.Schema, mb[1])
 				forceSavePos = true


### PR DESCRIPTION
module Canal:
When received a replication.QueryEvent, check if it is ALTER TABLE Query. 
If true, clear the table cache