### PR TITLE
repliaction: use meta to calculate length

### DIFF
--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -464,8 +464,8 @@ func (e *RowsEvent) decodeValue(data []byte, tp byte, meta uint16) (v interface{
 	case MYSQL_TYPE_STRING:
 		v, n = decodeString(data, length)
 	case MYSQL_TYPE_JSON:
-		// Refer https://github.com/shyiko/mysql-binlog-connector-java/blob/8f9132ee773317e00313204beeae8ddcaa43c1b4/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/AbstractRowsEventDataDeserializer.java#L344
-		length = int(binary.LittleEndian.Uint32(data[0:]))
+		// Refer: https://github.com/shyiko/mysql-binlog-connector-java/blob/master/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/AbstractRowsEventDataDeserializer.java#L404
+		length = int(FixedLengthInt(data[0:meta]))
 		n = length + int(meta)
 		v, err = decodeJsonBinary(data[meta:n])
 	case MYSQL_TYPE_GEOMETRY:


### PR DESCRIPTION
Hi @shyiko 

I find that you have already used `meta` instead of `4` to calculate the JSON length, so I change it too. But I have no time to port all your tests, maybe later. 

But very interesting that I find the MySQL source code in `log_event_print_value`:

```
  case MYSQL_TYPE_JSON:
    my_snprintf(typestr, typestr_length, "JSON");
    if (!ptr)
      return my_b_printf(file, "NULL");
    length= uint2korr(ptr);
    my_b_write_quoted(file, ptr + meta, length);
    return length + meta;
```

Seem that MySQL use 2 bytes to calculate the length, but it can't work in my test if I use 2 too.

/cc @shlomi-noach This may be a risk for JSON type ,although now I for all my test the meta is 4. 