### PR TITLE
canal add auto ClearTableCache when table structure changed

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -215,6 +215,14 @@ func (c *Canal) GetTable(db string, table string) (*schema.Table, error) {
 	return t, nil
 }
 
+// ClearTableCache clear table cache
+func (c *Canal) ClearTableCache(db []byte, table []byte) {
+	key := fmt.Sprintf("%s.%s", db, table)
+	c.tableLock.Lock()
+	delete(c.tables, key)
+	c.tableLock.Unlock()
+}
+
 // Check MySQL binlog row image, must be in FULL, MINIMAL, NOBLOB
 func (c *Canal) CheckBinlogRowImage(image string) error {
 	// need to check MySQL binlog row image? full, minimal or noblob?

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -1,6 +1,7 @@
 package canal
 
 import (
+	"regexp"
 	"time"
 
 	"golang.org/x/net/context"
@@ -9,6 +10,10 @@ import (
 	"github.com/ngaut/log"
 	"github.com/siddontang/go-mysql/mysql"
 	"github.com/siddontang/go-mysql/replication"
+)
+
+var (
+	expAlterTable = regexp.MustCompile("(?i)^ALTER\\sTABLE\\s.*?`{0,1}(.*?)`{0,1}\\.{0,1}`{0,1}([^`\\.]+?)`{0,1}\\s.*")
 )
 
 func (c *Canal) startSyncBinlog() error {
@@ -64,6 +69,19 @@ func (c *Canal) startSyncBinlog() error {
 			continue
 		case *replication.XIDEvent:
 			// try to save the position later
+		case *replication.QueryEvent:
+			// handle alert table query
+			if mb := expAlterTable.FindSubmatch(e.Query); mb != nil {
+				if len(mb[1]) == 0 {
+					mb[1] = e.Schema
+				}
+				c.ClearTableCache(mb[1], mb[2])
+				log.Infof("table structure changed, clear table cache: %s.%s %s\n", mb[1], mb[2])
+				forceSavePos = true
+			} else {
+				// skip others
+				continue
+			}
 		default:
 			continue
 		}

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -76,7 +76,7 @@ func (c *Canal) startSyncBinlog() error {
 					mb[1] = e.Schema
 				}
 				c.ClearTableCache(mb[1], mb[2])
-				log.Infof("table structure changed, clear table cache: %s.%s %s\n", mb[1], mb[2])
+				log.Infof("table structure changed, clear table cache: %s.%s\n", mb[1], mb[2])
 				forceSavePos = true
 			} else {
 				// skip others


### PR DESCRIPTION
module Canal:
When received a replication.QueryEvent, check if it is ALTER TABLE Query.
If true, clear the table cache

add test into canal_test.go