### PR TITLE
Stop doing a Reset() in ParseReader. It is unnecessary and limiting

### DIFF
--- a/replication/parser.go
+++ b/replication/parser.go
@@ -60,8 +60,6 @@ func (p *BinlogParser) ParseFile(name string, offset int64, onEvent OnEventFunc)
 }
 
 func (p *BinlogParser) ParseReader(r io.Reader, onEvent OnEventFunc) error {
-	p.Reset()
-
 	var err error
 	var n int64
 


### PR DESCRIPTION
Avoid calling *BinlogParser.Reset() in *BinlogParser.ParseReader()

see: https://github.com/siddontang/go-mysql/pull/132 for discussion

This allows streaming data into the parser from files incrementally instead of all at once.