### PR TITLE
Handle when missing table map at log start

### DIFF
--- a/replication/parser.go
+++ b/replication/parser.go
@@ -100,7 +100,10 @@ func (p *BinlogParser) ParseReader(r io.Reader, onEvent OnEventFunc) error {
 		var e Event
 		e, err = p.parseEvent(h, data)
 		if err != nil {
-			break
+			if _, ok := err.(missingTableMapEvent); ok {
+				continue
+			}
+			return errors.Trace(err)
 		}
 
 		if err = onEvent(&BinlogEvent{rawData, h, e}); err != nil {

--- a/replication/parser.go
+++ b/replication/parser.go
@@ -100,7 +100,7 @@ func (p *BinlogParser) ParseReader(r io.Reader, onEvent OnEventFunc) error {
 		var e Event
 		e, err = p.parseEvent(h, data)
 		if err != nil {
-			if _, ok := err.(missingTableMapEvent); ok {
+			if _, ok := err.(errMissingTableMapEvent); ok {
 				continue
 			}
 			return errors.Trace(err)

--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -15,7 +15,7 @@ import (
 	"github.com/siddontang/go/hack"
 )
 
-type missingTableMapEvent error
+type errMissingTableMapEvent error
 
 type TableMapEvent struct {
 	tableIDSize int
@@ -264,7 +264,7 @@ func (e *RowsEvent) Decode(data []byte) error {
 		if len(e.tables) > 0 {
 			return errors.Errorf("invalid table id %d, no corresponding table map event", e.TableID)
 		} else {
-			return missingTableMapEvent(errors.Errorf("invalid table id %d, no corresponding table map event", e.TableID))
+			return errMissingTableMapEvent(errors.Errorf("invalid table id %d, no corresponding table map event", e.TableID))
 		}
 	}
 

--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -15,6 +15,8 @@ import (
 	"github.com/siddontang/go/hack"
 )
 
+type missingTableMapEvent error
+
 type TableMapEvent struct {
 	tableIDSize int
 
@@ -259,7 +261,11 @@ func (e *RowsEvent) Decode(data []byte) error {
 	var ok bool
 	e.Table, ok = e.tables[e.TableID]
 	if !ok {
-		return errors.Errorf("invalid table id %d, no correspond table map event", e.TableID)
+		if len(e.tables) > 0 {
+			return errors.Errorf("invalid table id %d, no corresponding table map event", e.TableID)
+		} else {
+			return missingTableMapEvent(errors.Errorf("invalid table id %d, no corresponding table map event", e.TableID))
+		}
 	}
 
 	var err error


### PR DESCRIPTION
It turns our that when MySQL writes its binary log files that during log file rotation MySQL can and will put the table map event at the end of one file with some or all of the rows events at the beginning of the next file (after the FDE's of course.)  I am not sure if this is possible to encounter when pretending to be a MySQL slave to a MySQL master and streaming the logs that way but it's 100% possible when dealing with the files themselves.

It also turns out that when an event fails parsing that we're returning what looks like a success from ParseData (a nil error because of the break instead of a return.)