### PR TITLE
add master slave heartbeat and kill invalid thread id

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -275,13 +275,15 @@ func (c *Canal) prepareSyncer() error {
 	}
 
 	cfg := replication.BinlogSyncerConfig{
-		ServerID: c.cfg.ServerID,
-		Flavor:   c.cfg.Flavor,
-		Host:     seps[0],
-		Port:     uint16(port),
-		User:     c.cfg.User,
-		Password: c.cfg.Password,
-		Charset:  c.cfg.Charset,
+		ServerID:        c.cfg.ServerID,
+		Flavor:          c.cfg.Flavor,
+		Host:            seps[0],
+		Port:            uint16(port),
+		User:            c.cfg.User,
+		Password:        c.cfg.Password,
+		Charset:         c.cfg.Charset,
+		HeartbeatPeriod: c.cfg.HeartbeatPeriod,
+		ReadTimeout:     c.cfg.ReadTimeout,
 	}
 
 	c.syncer = replication.NewBinlogSyncer(&cfg)

--- a/canal/canal_test.go
+++ b/canal/canal_test.go
@@ -4,9 +4,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
 	"testing"
 	"time"
 
@@ -62,21 +59,9 @@ func (s *canalTestSuite) SetUpSuite(c *C) {
 }
 
 func (s *canalTestSuite) TearDownSuite(c *C) {
-	sc := make(chan os.Signal, 1)
-	go func() {
-		// To test the heartbeat and read timeout,so need to sleep 4 seconds without data transmission
-		time.Sleep(4 * time.Second)
-		sc <- syscall.SIGTERM
-	}()
-
-	signal.Notify(sc,
-		os.Kill,
-		os.Interrupt,
-		syscall.SIGHUP,
-		syscall.SIGINT,
-		syscall.SIGTERM,
-		syscall.SIGQUIT)
-	<-sc
+	// To test the heartbeat and read timeout,so need to sleep 4 seconds without data transmission
+	log.Infof("Start testing the heartbeat and read timeout")
+	time.Sleep(4 * time.Second)
 
 	if s.c != nil {
 		s.c.Close()

--- a/canal/canal_test.go
+++ b/canal/canal_test.go
@@ -28,8 +28,8 @@ func (s *canalTestSuite) SetUpSuite(c *C) {
 	cfg := NewDefaultConfig()
 	cfg.Addr = fmt.Sprintf("%s:3306", *testHost)
 	cfg.User = "root"
-	cfg.HeartbeatPeriod = 2
-	cfg.ReadTimeout = 3
+	cfg.HeartbeatPeriod = 200 * time.Millisecond
+	cfg.ReadTimeout = 300 * time.Millisecond
 	cfg.Dump.ExecutionPath = "mysqldump"
 	cfg.Dump.TableDB = "test"
 	cfg.Dump.Tables = []string{"canal_test"}
@@ -59,9 +59,9 @@ func (s *canalTestSuite) SetUpSuite(c *C) {
 }
 
 func (s *canalTestSuite) TearDownSuite(c *C) {
-	// To test the heartbeat and read timeout,so need to sleep 4 seconds without data transmission
+	// To test the heartbeat and read timeout,so need to sleep 1 seconds without data transmission
 	log.Infof("Start testing the heartbeat and read timeout")
-	time.Sleep(4 * time.Second)
+	time.Sleep(time.Second)
 
 	if s.c != nil {
 		s.c.Close()

--- a/canal/config.go
+++ b/canal/config.go
@@ -40,7 +40,7 @@ type Config struct {
 	Charset         string        `toml:"charset"`
 	ServerID        uint32        `toml:"server_id"`
 	Flavor          string        `toml:"flavor"`
-	HeartbeatPeriod uint          `toml:"heartbeat_period"`
+	HeartbeatPeriod time.Duration `toml:"heartbeat_period"`
 	ReadTimeout     time.Duration `toml:"read_timeout"`
 
 	Dump DumpConfig `toml:"dump"`

--- a/canal/config.go
+++ b/canal/config.go
@@ -37,9 +37,11 @@ type Config struct {
 	User     string `toml:"user"`
 	Password string `toml:"password"`
 
-	Charset  string `toml:"charset"`
-	ServerID uint32 `toml:"server_id"`
-	Flavor   string `toml:"flavor"`
+	Charset         string        `toml:"charset"`
+	ServerID        uint32        `toml:"server_id"`
+	Flavor          string        `toml:"flavor"`
+	HeartbeatPeriod uint          `toml:"heartbeat_period"`
+	ReadTimeout     time.Duration `toml:"read_timeout"`
 
 	Dump DumpConfig `toml:"dump"`
 }

--- a/cmd/go-canal/main.go
+++ b/cmd/go-canal/main.go
@@ -7,7 +7,6 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/siddontang/go-mysql/canal"
 	"github.com/siddontang/go-mysql/mysql"
@@ -31,8 +30,8 @@ var ignoreTables = flag.String("ignore_tables", "", "ignore tables, must be data
 var startName = flag.String("bin_name", "", "start sync from binlog name")
 var startPos = flag.Uint("bin_pos", 0, "start sync from binlog position of")
 
-var heartbeatPeriod = flag.Uint("heartbeat", 60, "master heartbeat period")
-var readTimeout = flag.Uint("read_timeout", 90, "connection read timeout")
+var heartbeatPeriod = flag.Duration("heartbeat", 60, "master heartbeat period")
+var readTimeout = flag.Duration("read_timeout", 90, "connection read timeout")
 
 func main() {
 	flag.Parse()
@@ -43,7 +42,7 @@ func main() {
 	cfg.Password = *password
 	cfg.Flavor = *flavor
 
-	cfg.ReadTimeout = time.Duration(*readTimeout)
+	cfg.ReadTimeout = *readTimeout
 	cfg.HeartbeatPeriod = *heartbeatPeriod
 
 	cfg.ServerID = uint32(*serverID)

--- a/cmd/go-canal/main.go
+++ b/cmd/go-canal/main.go
@@ -32,7 +32,7 @@ var startName = flag.String("bin_name", "", "start sync from binlog name")
 var startPos = flag.Uint("bin_pos", 0, "start sync from binlog position of")
 
 var heartbeatPeriod = flag.Uint("heartbeat", 60, "master heartbeat period")
-var readTimeout = flag.Uint("read_timeout", 5, "connection read timeout")
+var readTimeout = flag.Uint("read_timeout", 90, "connection read timeout")
 
 func main() {
 	flag.Parse()

--- a/cmd/go-canal/main.go
+++ b/cmd/go-canal/main.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/siddontang/go-mysql/canal"
 	"github.com/siddontang/go-mysql/mysql"
@@ -30,6 +31,9 @@ var ignoreTables = flag.String("ignore_tables", "", "ignore tables, must be data
 var startName = flag.String("bin_name", "", "start sync from binlog name")
 var startPos = flag.Uint("bin_pos", 0, "start sync from binlog position of")
 
+var heartbeatPeriod = flag.Uint("heartbeat", 60, "master heartbeat period")
+var readTimeout = flag.Uint("read_timeout", 5, "connection read timeout")
+
 func main() {
 	flag.Parse()
 
@@ -38,6 +42,9 @@ func main() {
 	cfg.User = *user
 	cfg.Password = *password
 	cfg.Flavor = *flavor
+
+	cfg.ReadTimeout = time.Duration(*readTimeout)
+	cfg.HeartbeatPeriod = *heartbeatPeriod
 
 	cfg.ServerID = uint32(*serverID)
 	cfg.Dump.ExecutionPath = *mysqldump

--- a/cmd/go-canal/main.go
+++ b/cmd/go-canal/main.go
@@ -31,8 +31,8 @@ var ignoreTables = flag.String("ignore_tables", "", "ignore tables, must be data
 var startName = flag.String("bin_name", "", "start sync from binlog name")
 var startPos = flag.Uint("bin_pos", 0, "start sync from binlog position of")
 
-var heartbeatPeriod = flag.Duration("heartbeat", 60, "master heartbeat period")
-var readTimeout = flag.Duration("read_timeout", 90, "connection read timeout")
+var heartbeatPeriod = flag.Duration("heartbeat", 60*time.Second, "master heartbeat period")
+var readTimeout = flag.Duration("read_timeout", 90*time.Second, "connection read timeout")
 
 func main() {
 	flag.Parse()
@@ -43,8 +43,8 @@ func main() {
 	cfg.Password = *password
 	cfg.Flavor = *flavor
 
-	cfg.ReadTimeout = *readTimeout * time.Second
-	cfg.HeartbeatPeriod = *heartbeatPeriod * time.Second
+	cfg.ReadTimeout = *readTimeout
+	cfg.HeartbeatPeriod = *heartbeatPeriod
 	cfg.ServerID = uint32(*serverID)
 	cfg.Dump.ExecutionPath = *mysqldump
 	cfg.Dump.DiscardErr = false

--- a/cmd/go-canal/main.go
+++ b/cmd/go-canal/main.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/siddontang/go-mysql/canal"
 	"github.com/siddontang/go-mysql/mysql"
@@ -42,9 +43,8 @@ func main() {
 	cfg.Password = *password
 	cfg.Flavor = *flavor
 
-	cfg.ReadTimeout = *readTimeout
-	cfg.HeartbeatPeriod = *heartbeatPeriod
-
+	cfg.ReadTimeout = *readTimeout * time.Second
+	cfg.HeartbeatPeriod = *heartbeatPeriod * time.Second
 	cfg.ServerID = uint32(*serverID)
 	cfg.Dump.ExecutionPath = *mysqldump
 	cfg.Dump.DiscardErr = false

--- a/mysql/error.go
+++ b/mysql/error.go
@@ -57,3 +57,10 @@ func NewError(errCode uint16, message string) *MyError {
 
 	return e
 }
+
+func ErrorCode(errMsg string) (code int) {
+	var tmpStr string
+	// golang scanf doesn't support %*,so I used a temporary variable
+	fmt.Sscanf(errMsg, "%s%d", &tmpStr, &code)
+	return
+}

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -151,3 +151,17 @@ func (t *mysqlTestSuite) TestMysqlParseBinaryUint64(c *check.C) {
 	u64 := ParseBinaryUint64([]byte{1, 2, 3, 4, 5, 6, 7, 128})
 	c.Assert(u64, check.Equals, 128*uint64(72057594037927936)+7*uint64(281474976710656)+6*uint64(1099511627776)+5*uint64(4294967296)+4*16777216+3*65536+2*256+1)
 }
+
+func (t *mysqlTestSuite) TestErrorCode(c *check.C) {
+	var code int
+	code = ErrorCode("ERROR 1094 (HY000): Unknown thread id: 1094")
+	c.Assert(code, check.Equals, 1094)
+	code = ErrorCode("error string")
+	c.Assert(code, check.Equals, 0)
+	code = ErrorCode("abcdefg")
+	c.Assert(code, check.Equals, 0)
+	code = ErrorCode("123455 ks094")
+	c.Assert(code, check.Equals, 0)
+	code = ErrorCode("ERROR 1046 (3D000): Unknown error 1046")
+	c.Assert(code, check.Equals, 1046)
+}

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -153,15 +153,17 @@ func (t *mysqlTestSuite) TestMysqlParseBinaryUint64(c *check.C) {
 }
 
 func (t *mysqlTestSuite) TestErrorCode(c *check.C) {
-	var code int
-	code = ErrorCode("ERROR 1094 (HY000): Unknown thread id: 1094")
-	c.Assert(code, check.Equals, 1094)
-	code = ErrorCode("error string")
-	c.Assert(code, check.Equals, 0)
-	code = ErrorCode("abcdefg")
-	c.Assert(code, check.Equals, 0)
-	code = ErrorCode("123455 ks094")
-	c.Assert(code, check.Equals, 0)
-	code = ErrorCode("ERROR 1046 (3D000): Unknown error 1046")
-	c.Assert(code, check.Equals, 1046)
+	tbls := []struct {
+		msg  string
+		code int
+	}{
+		{"ERROR 1094 (HY000): Unknown thread id: 1094", 1094},
+		{"error string", 0},
+		{"abcdefg", 0},
+		{"123455 ks094", 0},
+		{"ERROR 1046 (3D000): Unknown error 1046", 1046},
+	}
+	for _, v := range tbls {
+		c.Assert(ErrorCode(v.msg), check.Equals, v.code)
+	}
 }

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -191,13 +191,9 @@ func (b *BinlogSyncer) registerSlave() error {
 	if b.lastConnectionID > 0 {
 		cmd := fmt.Sprintf("KILL %d", b.lastConnectionID)
 		if _, err := b.c.Execute(cmd); err != nil {
-			log.Errorf("b.c.Execute(%s) error(%v)", cmd, err)
-			var tmpStr string
-			var code int
-			// golang scanf doesn't support %*,so I used a temporary variable
-			fmt.Sscanf(err.Error(), "%s%d", &tmpStr, &code)
+			log.Errorf("kill connection %d error %v", b.lastConnectionID, err)
 			// Unknown thread id
-			if code != ER_NO_SUCH_THREAD {
+			if code := ErrorCode(err.Error()); code != ER_NO_SUCH_THREAD {
 				return errors.Trace(err)
 			}
 		}

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -178,7 +178,9 @@ func (b *BinlogSyncer) registerSlave() error {
 	}
 
 	//set read timeout
-	b.c.SetReadDeadline(time.Now().Add(time.Second * b.cfg.ReadTimeout))
+	if b.cfg.ReadTimeout > 0 {
+		b.c.SetReadDeadline(time.Now().Add(time.Second * b.cfg.ReadTimeout))
+	}
 
 	if b.cfg.RecvBufferSize > 0 {
 		if tcp, ok := b.c.Conn.Conn.(*net.TCPConn); ok {
@@ -620,7 +622,9 @@ func (b *BinlogSyncer) onStream(s *BinlogStreamer) {
 		}
 
 		//set read timeout
-		b.c.SetReadDeadline(time.Now().Add(time.Second * b.cfg.ReadTimeout))
+		if b.cfg.ReadTimeout > 0 {
+			b.c.SetReadDeadline(time.Now().Add(time.Second * b.cfg.ReadTimeout))
+		}
 
 		switch data[0] {
 		case OK_HEADER:

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -178,7 +178,7 @@ func (b *BinlogSyncer) registerSlave() error {
 
 	//set read timeout
 	if b.cfg.ReadTimeout > 0 {
-		b.c.SetReadDeadline(time.Now().Add(time.Second * b.cfg.ReadTimeout))
+		b.c.SetReadDeadline(time.Now().Add(b.cfg.ReadTimeout))
 	}
 
 	if b.cfg.RecvBufferSize > 0 {
@@ -239,10 +239,9 @@ func (b *BinlogSyncer) registerSlave() error {
 	}
 
 	if b.cfg.HeartbeatPeriod > 0 {
-		nanosecond := b.cfg.HeartbeatPeriod * 1000000000
-		_, err = b.c.Execute(fmt.Sprintf("SET @master_heartbeat_period=%d;", nanosecond))
+		_, err = b.c.Execute(fmt.Sprintf("SET @master_heartbeat_period=%d;", b.cfg.HeartbeatPeriod))
 		if err != nil {
-			log.Error("failed to set @master_heartbeat_period=%d", nanosecond, err)
+			log.Error("failed to set @master_heartbeat_period=%d", b.cfg.HeartbeatPeriod, err)
 			return errors.Trace(err)
 		}
 	}
@@ -622,7 +621,7 @@ func (b *BinlogSyncer) onStream(s *BinlogStreamer) {
 
 		//set read timeout
 		if b.cfg.ReadTimeout > 0 {
-			b.c.SetReadDeadline(time.Now().Add(time.Second * b.cfg.ReadTimeout))
+			b.c.SetReadDeadline(time.Now().Add(b.cfg.ReadTimeout))
 		}
 
 		switch data[0] {


### PR DESCRIPTION
When the network jitter or other reasons, the mysql server does not kill invalid canal database connection, which can cause waste of resources, at the same time, with the heartbeat set, canal initiative to kill invalid connection, and to connect to the database