### PR TITLE
Expose public method for syncer's next position

### DIFF
--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -270,8 +270,8 @@ func (b *BinlogSyncer) startDumpStream() *BinlogStreamer {
 }
 
 // GetNextPosition returns the next position of the syncer
-func (b *BinlogSyncer) GetNextPosition() *Position {
-	return &b.nextPos
+func (b *BinlogSyncer) GetNextPosition() Position {
+	return b.nextPos
 }
 
 // StartSync starts syncing from the `pos` position.

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -269,6 +269,11 @@ func (b *BinlogSyncer) startDumpStream() *BinlogStreamer {
 	return s
 }
 
+// GetNextPosition returns the next position of the syncer
+func (b *BinlogSyncer) GetNextPosition() *Position {
+	return &b.nextPos
+}
+
 // StartSync starts syncing from the `pos` position.
 func (b *BinlogSyncer) StartSync(pos Position) (*BinlogStreamer, error) {
 	log.Infof("begin to sync binlog from position %s", pos)


### PR DESCRIPTION
For my project, it is useful to have a reference to the next position that the syncer will read from :)