### PR TITLE
Add MaxAllowedPacketMB config to mysqldump args

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -107,6 +107,7 @@ func (c *Canal) prepareDumper() error {
 	c.dumper.SetCharset(charset)
 
 	c.dumper.SkipMasterData(c.cfg.Dump.SkipMasterData)
+	c.dumper.SetMaxAllowedPacket(c.cfg.Dump.MaxAllowedPacketMB)
 
 	for _, ignoreTable := range c.cfg.Dump.IgnoreTables {
 		if seps := strings.Split(ignoreTable, ","); len(seps) == 2 {

--- a/canal/config.go
+++ b/canal/config.go
@@ -30,6 +30,9 @@ type DumpConfig struct {
 	// Set true to skip --master-data if we have no privilege to do
 	// 'FLUSH TABLES WITH READ LOCK'
 	SkipMasterData bool `toml:"skip_master_data"`
+
+	// Set to change the default max_allowed_packet size
+	MaxAllowedPacketMB int
 }
 
 type Config struct {

--- a/canal/config.go
+++ b/canal/config.go
@@ -32,7 +32,7 @@ type DumpConfig struct {
 	SkipMasterData bool `toml:"skip_master_data"`
 
 	// Set to change the default max_allowed_packet size
-	MaxAllowedPacketMB int
+	MaxAllowedPacketMB int `toml:"max_allowed_packet_mb"`
 }
 
 type Config struct {

--- a/dump/dump.go
+++ b/dump/dump.go
@@ -33,6 +33,7 @@ type Dumper struct {
 	ErrOut io.Writer
 
 	masterDataSkipped bool
+	maxAllowedPacket  int
 }
 
 func NewDumper(executionPath string, addr string, user string, password string) (*Dumper, error) {
@@ -72,6 +73,10 @@ func (d *Dumper) SetErrOut(o io.Writer) {
 // In some cloud MySQL, we have no privilege to use `--master-data`.
 func (d *Dumper) SkipMasterData(v bool) {
 	d.masterDataSkipped = v
+}
+
+func (d *Dumper) SetMaxAllowedPacket(i int) {
+	d.maxAllowedPacket = i
 }
 
 func (d *Dumper) AddDatabases(dbs ...string) {
@@ -115,6 +120,10 @@ func (d *Dumper) Dump(w io.Writer) error {
 
 	if !d.masterDataSkipped {
 		args = append(args, "--master-data")
+	}
+
+	if d.maxAllowedPacket > 0 {
+		args = append(args, fmt.Sprintf("--max_allowed_packet=%dM", d.maxAllowedPacket))
 	}
 
 	args = append(args, "--single-transaction")


### PR DESCRIPTION
This is required if needing to increase the default max_packet_size for mysqldump, otherwise I see

```mysqldump: Error 2020: Got packet bigger than 'max_allowed_packet' bytes when dumping table```

Thanks!