### PR TITLE
use context to replace golang.org/net/x/context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.6
   - 1.7
+  - 1.8
 
 dist: trusty
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.7
   - 1.8
+  - 1.9
 
 dist: trusty
 sudo: required

--- a/canal/canal.go
+++ b/canal/canal.go
@@ -1,6 +1,7 @@
 package canal
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -15,7 +16,6 @@ import (
 	"github.com/siddontang/go-mysql/mysql"
 	"github.com/siddontang/go-mysql/replication"
 	"github.com/siddontang/go-mysql/schema"
-	"golang.org/x/net/context"
 )
 
 // Canal can sync your MySQL data into everywhere, like Elasticsearch, Redis, etc...

--- a/cmd/go-mysqlbinlog/main.go
+++ b/cmd/go-mysqlbinlog/main.go
@@ -4,11 +4,10 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
-
-	"golang.org/x/net/context"
 
 	"github.com/juju/errors"
 	"github.com/siddontang/go-mysql/mysql"
@@ -45,7 +44,7 @@ func main() {
 		SemiSyncEnabled: *semiSync,
 	}
 
-	b := replication.NewBinlogSyncer(cfg)
+	b := replication.NewBinlogSyncer(&cfg)
 
 	pos := mysql.Position{*file, uint32(*pos)}
 	if len(*backupPath) > 0 {

--- a/cmd/go-mysqlbinlog/main.go
+++ b/cmd/go-mysqlbinlog/main.go
@@ -44,7 +44,7 @@ func main() {
 		SemiSyncEnabled: *semiSync,
 	}
 
-	b := replication.NewBinlogSyncer(&cfg)
+	b := replication.NewBinlogSyncer(cfg)
 
 	pos := mysql.Position{*file, uint32(*pos)}
 	if len(*backupPath) > 0 {

--- a/replication/backup.go
+++ b/replication/backup.go
@@ -1,12 +1,11 @@
 package replication
 
 import (
+	"context"
 	"io"
 	"os"
 	"path"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/juju/errors"
 	. "github.com/siddontang/go-mysql/mysql"

--- a/replication/binlogstreamer.go
+++ b/replication/binlogstreamer.go
@@ -1,7 +1,7 @@
 package replication
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/juju/errors"
 	"github.com/ngaut/log"

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -1,6 +1,7 @@
 package replication
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/binary"
 	"fmt"
@@ -8,8 +9,6 @@ import (
 	"os"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/juju/errors"
 	"github.com/ngaut/log"

--- a/replication/replication_test.go
+++ b/replication/replication_test.go
@@ -1,14 +1,13 @@
 package replication
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
 	"sync"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 
 	. "github.com/pingcap/check"
 	uuid "github.com/satori/go.uuid"


### PR DESCRIPTION
Use package "context" to replace "golang.org/net/x/context".