### PR TITLE
TWEAK: do not set global log level in NewBinlogSyncer

### DIFF
--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -57,8 +57,6 @@ type BinlogSyncerConfig struct {
 	// We will use Local location for timestamp and UTC location for datatime.
 	ParseTime bool
 
-	LogLevel string
-
 	// RecvBufferSize sets the size in bytes of the operating system's receive buffer associated with the connection.
 	RecvBufferSize int
 
@@ -97,11 +95,6 @@ type BinlogSyncer struct {
 
 // NewBinlogSyncer creates the BinlogSyncer with cfg.
 func NewBinlogSyncer(cfg BinlogSyncerConfig) *BinlogSyncer {
-	if cfg.LogLevel == "" {
-		cfg.LogLevel = "info"
-	}
-	log.SetLevelByString(cfg.LogLevel)
-
 	// Clear the Password to avoid outputing it in log.
 	pass := cfg.Password
 	cfg.Password = ""


### PR DESCRIPTION
This reverts https://github.com/siddontang/go-mysql/commit/0baad4d700af91f9031f5b4e3135f4eb53ed35ce.

Setting a global log level in an initializer causes unwanted side effects in many cases. User who needs this should do `log.SetLevelByString` in main program only.