### PR TITLE
Fix update MariaDB GTID

### DIFF
--- a/canal/sync.go
+++ b/canal/sync.go
@@ -92,7 +92,7 @@ func (c *Canal) runSyncBinlog() error {
 			}
 		case *replication.MariadbGTIDEvent:
 			// try to save the GTID later
-			gtid := e.GTID
+			gtid := &e.GTID
 			c.master.UpdateGTID(gtid)
 			if err := c.eventHandler.OnGTID(gtid); err != nil {
 				return errors.Trace(err)

--- a/failover/mariadb_gtid_handler.go
+++ b/failover/mariadb_gtid_handler.go
@@ -51,7 +51,7 @@ func (h *MariadbGTIDHandler) FindBestSlaves(slaves []*Server) ([]*Server, error)
 				return nil, errors.Trace(err)
 			}
 
-			seq = g.(MariadbGTID).SequenceNumber
+			seq = g.(*MariadbGTID).SequenceNumber
 		}
 
 		ps[i] = seq

--- a/mysql/mariadb_gtid.go
+++ b/mysql/mariadb_gtid.go
@@ -17,12 +17,12 @@ type MariadbGTID struct {
 // We don't support multi source replication, so the mariadb gtid set may have only domain-server-sequence
 func ParseMariadbGTIDSet(str string) (GTIDSet, error) {
 	if len(str) == 0 {
-		return MariadbGTID{0, 0, 0}, nil
+		return &MariadbGTID{0, 0, 0}, nil
 	}
 
 	seps := strings.Split(str, "-")
 
-	var gtid MariadbGTID
+	gtid := new(MariadbGTID)
 
 	if len(seps) != 3 {
 		return gtid, errors.Errorf("invalid Mariadb GTID %v, must domain-server-sequence", str)
@@ -43,13 +43,13 @@ func ParseMariadbGTIDSet(str string) (GTIDSet, error) {
 		return gtid, errors.Errorf("invalid MariaDB GTID Sequence number (%v): %v", seps[2], err)
 	}
 
-	return MariadbGTID{
+	return &MariadbGTID{
 		DomainID:       uint32(domainID),
 		ServerID:       uint32(serverID),
 		SequenceNumber: sequenceID}, nil
 }
 
-func (gtid MariadbGTID) String() string {
+func (gtid *MariadbGTID) String() string {
 	if gtid.DomainID == 0 && gtid.ServerID == 0 && gtid.SequenceNumber == 0 {
 		return ""
 	}
@@ -57,21 +57,21 @@ func (gtid MariadbGTID) String() string {
 	return fmt.Sprintf("%d-%d-%d", gtid.DomainID, gtid.ServerID, gtid.SequenceNumber)
 }
 
-func (gtid MariadbGTID) Encode() []byte {
+func (gtid *MariadbGTID) Encode() []byte {
 	return []byte(gtid.String())
 }
 
-func (gtid MariadbGTID) Equal(o GTIDSet) bool {
-	other, ok := o.(MariadbGTID)
+func (gtid *MariadbGTID) Equal(o GTIDSet) bool {
+	other, ok := o.(*MariadbGTID)
 	if !ok {
 		return false
 	}
 
-	return gtid == other
+	return gtid.DomainID == other.DomainID && gtid.ServerID == other.ServerID && gtid.SequenceNumber == other.SequenceNumber
 }
 
-func (gtid MariadbGTID) Contain(o GTIDSet) bool {
-	other, ok := o.(MariadbGTID)
+func (gtid *MariadbGTID) Contain(o GTIDSet) bool {
+	other, ok := o.(*MariadbGTID)
 	if !ok {
 		return false
 	}
@@ -79,13 +79,13 @@ func (gtid MariadbGTID) Contain(o GTIDSet) bool {
 	return gtid.DomainID == other.DomainID && gtid.SequenceNumber >= other.SequenceNumber
 }
 
-func (gtid MariadbGTID) Update(GTIDStr string) error {
+func (gtid *MariadbGTID) Update(GTIDStr string) error {
 	newGTID, err := ParseMariadbGTIDSet(GTIDStr)
 	if err != nil {
 		return err
 	}
 
-	gtid = newGTID.(MariadbGTID)
+	*gtid = *(newGTID.(*MariadbGTID))
 
 	return nil
 }

--- a/mysql/mariadb_gtid.go
+++ b/mysql/mariadb_gtid.go
@@ -67,7 +67,7 @@ func (gtid *MariadbGTID) Equal(o GTIDSet) bool {
 		return false
 	}
 
-	return gtid.DomainID == other.DomainID && gtid.ServerID == other.ServerID && gtid.SequenceNumber == other.SequenceNumber
+	return *gtid == *other
 }
 
 func (gtid *MariadbGTID) Contain(o GTIDSet) bool {

--- a/mysql/mariadb_gtid_test.go
+++ b/mysql/mariadb_gtid_test.go
@@ -9,11 +9,11 @@ type mariaDBTestSuite struct {
 
 var _ = check.Suite(&mariaDBTestSuite{})
 
-func (s *mariaDBTestSuite) SetUpSuite(c *check.C) {
+func (t *mariaDBTestSuite) SetUpSuite(c *check.C) {
 
 }
 
-func (s *mariaDBTestSuite) TearDownSuite(c *check.C) {
+func (t *mariaDBTestSuite) TearDownSuite(c *check.C) {
 
 }
 
@@ -34,8 +34,8 @@ func (t *mariaDBTestSuite) TestMariaDBEqual(c *check.C) {
 	g3, err := ParseMariadbGTIDSet("0-1-2")
 	c.Assert(err, check.IsNil)
 
-	c.Assert(g1.Equal(g2), check.Equals, true)
-	c.Assert(g1.Equal(g3), check.Equals, false)
+	c.Assert(g1.Equal(g2), check.IsTrue)
+	c.Assert(g1.Equal(g3), check.IsFalse)
 }
 
 func (t *mariaDBTestSuite) TestMariaDBUpdate(c *check.C) {

--- a/mysql/mariadb_gtid_test.go
+++ b/mysql/mariadb_gtid_test.go
@@ -1,0 +1,48 @@
+package mysql
+
+import (
+	"github.com/pingcap/check"
+)
+
+type mariaDBTestSuite struct {
+}
+
+var _ = check.Suite(&mariaDBTestSuite{})
+
+func (s *mariaDBTestSuite) SetUpSuite(c *check.C) {
+
+}
+
+func (s *mariaDBTestSuite) TearDownSuite(c *check.C) {
+
+}
+
+func (t *mariaDBTestSuite) TestParseMariadbGTIDSet(c *check.C) {
+	g1, err := ParseMariadbGTIDSet("0-1-1")
+	c.Assert(err, check.IsNil)
+
+	c.Assert(g1.String(), check.Equals, "0-1-1")
+}
+
+func (t *mariaDBTestSuite) TestMariaDBEqual(c *check.C) {
+	g1, err := ParseMariadbGTIDSet("0-1-1")
+	c.Assert(err, check.IsNil)
+
+	g2, err := ParseMariadbGTIDSet("0-1-1")
+	c.Assert(err, check.IsNil)
+
+	g3, err := ParseMariadbGTIDSet("0-1-2")
+	c.Assert(err, check.IsNil)
+
+	c.Assert(g1.Equal(g2), check.Equals, true)
+	c.Assert(g1.Equal(g3), check.Equals, false)
+}
+
+func (t *mariaDBTestSuite) TestMariaDBUpdate(c *check.C) {
+	g1, err := ParseMariadbGTIDSet("0-1-1")
+	c.Assert(err, check.IsNil)
+
+	g1.Update("0-1-2")
+
+	c.Assert(g1.String(), check.Equals, "0-1-2")
+}

--- a/mysql/mysql_gtid.go
+++ b/mysql/mysql_gtid.go
@@ -257,7 +257,7 @@ func (s *UUIDSet) decode(data []byte) (int, error) {
 	}
 	pos += 16
 
-	n := int64(binary.LittleEndian.Uint64(data[pos : pos+8]))
+	n := int64(binary.LittleEndian.Uint64(data[pos: pos+8]))
 	pos += 8
 	if len(data) < int(16*n)+pos {
 		return 0, errors.Errorf("invalid uuid set buffer, must %d, but %d", pos+int(16*n), len(data))
@@ -267,9 +267,9 @@ func (s *UUIDSet) decode(data []byte) (int, error) {
 
 	var in Interval
 	for i := int64(0); i < n; i++ {
-		in.Start = int64(binary.LittleEndian.Uint64(data[pos : pos+8]))
+		in.Start = int64(binary.LittleEndian.Uint64(data[pos: pos+8]))
 		pos += 8
-		in.Stop = int64(binary.LittleEndian.Uint64(data[pos : pos+8]))
+		in.Stop = int64(binary.LittleEndian.Uint64(data[pos: pos+8]))
 		pos += 8
 		s.Intervals = append(s.Intervals, in)
 	}

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -16,11 +16,11 @@ type mysqlTestSuite struct {
 
 var _ = check.Suite(&mysqlTestSuite{})
 
-func (s *mysqlTestSuite) SetUpSuite(c *check.C) {
+func (t *mysqlTestSuite) SetUpSuite(c *check.C) {
 
 }
 
-func (s *mysqlTestSuite) TearDownSuite(c *check.C) {
+func (t *mysqlTestSuite) TearDownSuite(c *check.C) {
 
 }
 

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pingcap/check"
@@ -89,6 +90,15 @@ func (t *mysqlTestSuite) TestMysqlGTIDCodec(c *check.C) {
 	o, err := DecodeMysqlGTIDSet(buf)
 	c.Assert(err, check.IsNil)
 	c.Assert(gs, check.DeepEquals, o)
+}
+
+func (t *mysqlTestSuite) TestMysqlUpdate(c *check.C) {
+	g1, err := ParseMysqlGTIDSet("3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57")
+	c.Assert(err, check.IsNil)
+
+	g1.Update("3E11FA47-71CA-11E1-9E33-C80AA9429562:21-58")
+
+	c.Assert(strings.ToUpper(g1.String()), check.Equals, "3E11FA47-71CA-11E1-9E33-C80AA9429562:21-58")
 }
 
 func (t *mysqlTestSuite) TestMysqlGTIDContain(c *check.C) {


### PR DESCRIPTION
Fix a bug ([here](https://github.com/siddontang/go-mysql/blob/c951d16871eb6829d4f53256e05cde906498428e/mysql/mariadb_gtid.go#L82))

use pointer receiver instead of value receiver.