### PR TITLE
为canal同步增加部分特殊场景处理

### DIFF
--- a/replication/binlogstreamer.go
+++ b/replication/binlogstreamer.go
@@ -2,6 +2,7 @@ package replication
 
 import (
 	"context"
+	"runtime"
 
 	"github.com/juju/errors"
 	log "github.com/sirupsen/logrus"
@@ -44,7 +45,14 @@ func (s *BinlogStreamer) closeWithError(err error) {
 	if err == nil {
 		err = ErrSyncClosed
 	}
-	log.Errorf("close sync with err: %v", err)
+	if err == ErrSyncClosed {
+		log.Infof("close sync with err: %v", err)
+	} else {
+		buf := make([]byte, 1024)
+		n := runtime.Stack(buf, false)
+		log.Errorf("close sync with err: %v, stack : %s", err, string(buf[0:n]))
+	}
+
 	select {
 	case s.ech <- err:
 	default:

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -14,6 +14,7 @@ import (
 )
 
 var ErrTableNotExist = errors.New("table is not exist")
+var LastGetTableInfoErr = errors.New("get last table error")
 
 const (
 	TYPE_NUMBER    = iota + 1 // tinyint, smallint, mediumint, int, bigint, year
@@ -56,7 +57,7 @@ type Table struct {
 }
 
 func (ta *Table) String() string {
-	return fmt.Sprintf("%s.%s", ta.Schema, ta.Name)
+	return ta.Schema + "." + ta.Name
 }
 
 func (ta *Table) AddColumn(name string, columnType string, collation string, extra string) {


### PR DESCRIPTION
[fix] fix canal stop when fetch table meta error
[refine] refine table meta fetch logic when fetch table meta error
[add] add get last error interface to canal

在做RDS同步的时候遇到一些问题：
1、RDS每过一段时间会rotate一个binlog，然后定期清除老的binlog，如果程序超过2天没有运行，之前保存的binlog checkpoint会失效，这个时候canal没办法工作。所以为canal增加一个get last error接口，发现error后，stop canal，判断error，如果是binlog不存在的问题，那重新开启一个canal，从默认位置同步
2、RDS中普通用户都没有mysql.ha_health_check这张表的读权限，所以默认加了meta，和Java的canal版本一致
3、在权限控制时，如果没有某些表读权限（不想同步），拿meta失败会停止工作。现在改成遇到拿meta失败后只是打印错误，继续处理后续数据。
4、如果3发生，且没读权限的表数据很多，会对master产生非常多无效的请求，因此加了个限制，超过10秒再拿一次meta。这样在授予权限之后还具备重新同步的能力

太忙了，就花了一两个小时改的，比较粗糙。另外我是go的新手，但感觉fmt.printf(%s.%s)的效率应该是低于a+"."+b的，所以忍不住改了一下。

最近我们准备拿go canal的进行生产数据同步，所以后面估计还会遇到很多问题，希望提的PR作者可以加到master分支，感谢！

钉钉：15851856153 