### PR TITLE
canel: remove Start and use Run

### DIFF
--- a/canal/canal_test.go
+++ b/canal/canal_test.go
@@ -53,8 +53,10 @@ func (s *canalTestSuite) SetUpSuite(c *C) {
 	s.execute(c, "SET GLOBAL binlog_format = 'ROW'")
 
 	s.c.SetEventHandler(&testEventHandler{c: c})
-	err = s.c.Start()
-	c.Assert(err, IsNil)
+	go func() {
+		err = s.c.Run()
+		c.Assert(err, IsNil)
+	}()
 }
 
 func (s *canalTestSuite) TearDownSuite(c *C) {

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -39,7 +39,6 @@ func (c *Canal) startSyncer() (*replication.BinlogStreamer, error) {
 }
 
 func (c *Canal) runSyncBinlog() error {
-
 	s, err := c.startSyncer()
 	if err != nil {
 		return err

--- a/cmd/go-canal/main.go
+++ b/cmd/go-canal/main.go
@@ -75,15 +75,16 @@ func main() {
 	c.SetEventHandler(&handler{})
 
 	startPos := mysql.Position{
-		*startName,
-		uint32(*startPos),
+		Name: *startName,
+		Pos:  uint32(*startPos),
 	}
 
-	err = c.StartFrom(startPos)
-	if err != nil {
-		fmt.Printf("start canal err %V", err)
-		os.Exit(1)
-	}
+	go func() {
+		err = c.RunFrom(startPos)
+		if err != nil {
+			fmt.Printf("start canal err %v", err)
+		}
+	}()
 
 	sc := make(chan os.Signal, 1)
 	signal.Notify(sc,


### PR DESCRIPTION
Origin Start will run Canal in another goroutine so we can't know whether it is still running or not, so here we export Run directly. When the Run returns, we can know that Canal meets an error or is closed.

To fix #183 