### PR TITLE
FormatDescriptionEvent should be readed by binlog file always

### DIFF
--- a/replication/parser.go
+++ b/replication/parser.go
@@ -50,6 +50,12 @@ func (p *BinlogParser) ParseFile(name string, offset int64, onEvent OnEventFunc)
 
 	if offset < 4 {
 		offset = 4
+	} else if offset > 4 {
+		if _, err = f.Seek(4, os.SEEK_SET); err != nil {
+			return errors.Errorf("seek %s to %d error %v", name, offset, err)
+		}
+
+		p.getFormatDescriptionEvent(f, onEvent)
 	}
 
 	if _, err = f.Seek(offset, os.SEEK_SET); err != nil {
@@ -59,46 +65,73 @@ func (p *BinlogParser) ParseFile(name string, offset int64, onEvent OnEventFunc)
 	return p.ParseReader(f, onEvent)
 }
 
-func (p *BinlogParser) ParseReader(r io.Reader, onEvent OnEventFunc) error {
+
+
+func (p *BinlogParser) getFormatDescriptionEvent(r io.Reader, onEvent OnEventFunc) error {
+	_, err := p.parseReaderSingleEvent(&r, onEvent)
+	return err
+}
+
+
+
+func (p *BinlogParser) parseReaderSingleEvent(r *io.Reader, onEvent OnEventFunc) (bool, error) {
 	var err error
 	var n int64
 
+	headBuf := make([]byte, EventHeaderSize)
+
+	if _, err = io.ReadFull(*r, headBuf); err == io.EOF {
+		return true, nil
+	} else if err != nil {
+		return false, errors.Trace(err)
+	}
+
+	var h *EventHeader
+	h, err = p.parseHeader(headBuf)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+
+	if h.EventSize <= uint32(EventHeaderSize) {
+		return false, errors.Errorf("invalid event header, event size is %d, too small", h.EventSize)
+	}
+
+	var buf bytes.Buffer
+	if n, err = io.CopyN(&buf, *r, int64(h.EventSize)-int64(EventHeaderSize)); err != nil {
+		return false, errors.Errorf("get event body err %v, need %d - %d, but got %d", err, h.EventSize, EventHeaderSize, n)
+	}
+
+	data := buf.Bytes()
+	rawData := data
+
+	eventLen := int(h.EventSize) - EventHeaderSize
+
+	if len(data) != eventLen {
+		return false, errors.Errorf("invalid data size %d in event %s, less event length %d", len(data), h.EventType, eventLen)
+	}
+
+	var e Event
+	e, err = p.parseEvent(h, data)
+	if err != nil {
+		if _, ok := err.(errMissingTableMapEvent); ok {
+			return false, nil
+		}
+		return false, errors.Trace(err)
+	}
+
+	if err = onEvent(&BinlogEvent{rawData, h, e}); err != nil {
+		return false, errors.Trace(err)
+	}
+
+
+	return false, nil
+}
+
+
+func (p *BinlogParser) ParseReader(r io.Reader, onEvent OnEventFunc) error {
+
 	for {
-		headBuf := make([]byte, EventHeaderSize)
-
-		if _, err = io.ReadFull(r, headBuf); err == io.EOF {
-			return nil
-		} else if err != nil {
-			return errors.Trace(err)
-		}
-
-		var h *EventHeader
-		h, err = p.parseHeader(headBuf)
-		if err != nil {
-			return errors.Trace(err)
-		}
-
-		if h.EventSize <= uint32(EventHeaderSize) {
-			return errors.Errorf("invalid event header, event size is %d, too small", h.EventSize)
-
-		}
-
-		var buf bytes.Buffer
-		if n, err = io.CopyN(&buf, r, int64(h.EventSize)-int64(EventHeaderSize)); err != nil {
-			return errors.Errorf("get event body err %v, need %d - %d, but got %d", err, h.EventSize, EventHeaderSize, n)
-		}
-
-		data := buf.Bytes()
-		rawData := data
-
-		eventLen := int(h.EventSize) - EventHeaderSize
-
-		if len(data) != eventLen {
-			return errors.Errorf("invalid data size %d in event %s, less event length %d", len(data), h.EventType, eventLen)
-		}
-
-		var e Event
-		e, err = p.parseEvent(h, data)
+		done, err := p.parseReaderSingleEvent(&r, onEvent); 
 		if err != nil {
 			if _, ok := err.(errMissingTableMapEvent); ok {
 				continue
@@ -106,8 +139,8 @@ func (p *BinlogParser) ParseReader(r io.Reader, onEvent OnEventFunc) error {
 			return errors.Trace(err)
 		}
 
-		if err = onEvent(&BinlogEvent{rawData, h, e}); err != nil {
-			return errors.Trace(err)
+		if done {
+			break
 		}
 	}
 

--- a/replication/parser.go
+++ b/replication/parser.go
@@ -51,6 +51,7 @@ func (p *BinlogParser) ParseFile(name string, offset int64, onEvent OnEventFunc)
 	if offset < 4 {
 		offset = 4
 	} else if offset > 4 {
+		//  FORMAT_DESCRIPTION event should be read by default always (despite that fact passed offset may be higher than 4)
 		if _, err = f.Seek(4, os.SEEK_SET); err != nil {
 			return errors.Errorf("seek %s to %d error %v", name, offset, err)
 		}
@@ -68,13 +69,13 @@ func (p *BinlogParser) ParseFile(name string, offset int64, onEvent OnEventFunc)
 
 
 func (p *BinlogParser) getFormatDescriptionEvent(r io.Reader, onEvent OnEventFunc) error {
-	_, err := p.parseReaderSingleEvent(&r, onEvent)
+	_, err := p.parseSingleEvent(&r, onEvent)
 	return err
 }
 
 
 
-func (p *BinlogParser) parseReaderSingleEvent(r *io.Reader, onEvent OnEventFunc) (bool, error) {
+func (p *BinlogParser) parseSingleEvent(r *io.Reader, onEvent OnEventFunc) (bool, error) {
 	var err error
 	var n int64
 
@@ -131,7 +132,7 @@ func (p *BinlogParser) parseReaderSingleEvent(r *io.Reader, onEvent OnEventFunc)
 func (p *BinlogParser) ParseReader(r io.Reader, onEvent OnEventFunc) error {
 
 	for {
-		done, err := p.parseReaderSingleEvent(&r, onEvent); 
+		done, err := p.parseSingleEvent(&r, onEvent); 
 		if err != nil {
 			if _, ok := err.(errMissingTableMapEvent); ok {
 				continue


### PR DESCRIPTION
if function ParseFile called with offset more than 4 then FormatDescriptionEvent would not be read because of the offset. Now FDEvent will be read by default if offset greater than 4