### PR TITLE
replication: expose last connectionID

### DIFF
--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -731,3 +731,8 @@ func (b *BinlogSyncer) getGtidSet() GTIDSet {
 
 	return gtidSet
 }
+
+// LastConnectionID returns last connectionID.
+func (b *BinlogSyncer) LastConnectionID() uint32 {
+	return b.lastConnectionID
+}


### PR DESCRIPTION
Currently, when `replication.BinlogSyncer ` closes, it doesn't close the connection showed in `show processlist` which may cause resources waste.  So, I want to expose `LastConnectionID` so the outer caller can kill the connection id when the connection is no longer need. 

According to mysql doc, the creater can kill the connection it created(SUPER privilege is not required).

```
If you have the PROCESS privilege, you can see all threads. If you have the SUPER privilege, you can kill all threads and statements. **Otherwise, you can see and kill only your own threads and statements**.
```