### PR TITLE
fix parse bug

### DIFF
--- a/dump/dump_test.go
+++ b/dump/dump_test.go
@@ -206,7 +206,7 @@ func (s *parserTestSuite) TestParseLine(c *C) {
 		return c == '\r' || c == '\n'
 	}
 
-	l := strings.TrimFunc(line, f)
+	l := strings.TrimRightFunc(line, f)
 
 	m := valuesExp.FindAllStringSubmatch(l, -1)
 

--- a/dump/dump_test.go
+++ b/dump/dump_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 
 	. "github.com/pingcap/check"
@@ -196,4 +197,21 @@ func (s *parserTestSuite) TestParseValue(c *C) {
 	str = `123,'\Z#÷QÎx£. Æ‘ÇoPâÅ_\r—\\','','qn\'`
 	values, err = parseValues(str)
 	c.Assert(err, NotNil)
+}
+
+func (s *parserTestSuite) TestParseLine(c *C) {
+	line := "INSERT INTO `test` VALUES (1, 'first', 'hello mysql; 2', 'e1', 'a,b');"
+
+	f := func(c rune) bool {
+		return c == '\r' || c == '\n'
+	}
+
+	l := strings.TrimFunc(line, f)
+
+	m := valuesExp.FindAllStringSubmatch(l, -1)
+
+	c.Assert(m, HasLen, 1)
+	c.Assert(m[0][1], Matches, "test")
+	c.Assert(m[0][2], Matches, "1, 'first', 'hello mysql; 2', 'e1', 'a,b'")
+
 }

--- a/dump/parser.go
+++ b/dump/parser.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"io"
 	"regexp"
-	"strings"
 	"strconv"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/siddontang/go-mysql/mysql"
@@ -50,9 +50,9 @@ func Parse(r io.Reader, h ParseHandler, parseBinlogPos bool) error {
 		}
 
 		// Ignore '\n' on Linux or '\r\n' on Windows
-        line = strings.TrimFunc(line, func(c rune) bool {
-            return c == '\r' || c == '\n'
-        })
+		line = strings.TrimRightFunc(line, func(c rune) bool {
+			return c == '\r' || c == '\n'
+		})
 
 		if parseBinlogPos && !binlogParsed {
 			if m := binlogExp.FindAllStringSubmatch(line, -1); len(m) == 1 {

--- a/dump/parser.go
+++ b/dump/parser.go
@@ -50,7 +50,9 @@ func Parse(r io.Reader, h ParseHandler, parseBinlogPos bool) error {
 		}
 
 		// Ignore '\n' on Linux or '\r\n' on Windows
-		line = strings.SplitAfter(line, ";")[0]
+        line = strings.TrimFunc(line, func(c rune) bool {
+            return c == '\r' || c == '\n'
+        })
 
 		if parseBinlogPos && !binlogParsed {
 			if m := binlogExp.FindAllStringSubmatch(line, -1); len(m) == 1 {


### PR DESCRIPTION
字段内容中包含 ";"时，会触发解析bug，导致解析的Sql语句不完整。
例如：
INSERT INTO test  (id, title, content, tenum, tset) VALUES (?, ?, ?, ?, ?)", 1, "first", "hello mysql; 2", "e1", "a,b")