### PR TITLE
Extend Handler interface with generic handler method

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -25,6 +25,10 @@ type Handler interface {
 	//handle COM_STMT_CLOSE, context is the previous one set in prepare
 	//this handler has no response
 	HandleStmtClose(context interface{}) error
+	//handle any other command that is not currently handled by the library,
+	//default implementation for this method should be:
+	//  return mysql.NewError(mysql.ER_UNKNOWN_ERROR, fmt.Sprintf("command %d is not supported now", cmd))
+	HandleOtherCommand(cmd byte, data []byte) error
 }
 
 func (c *Conn) HandleCommand() error {
@@ -119,8 +123,7 @@ func (c *Conn) dispatch(data []byte) interface{} {
 			return r
 		}
 	default:
-		msg := fmt.Sprintf("command %d is not supported now", cmd)
-		return NewError(ER_UNKNOWN_ERROR, msg)
+		return c.h.HandleOtherCommand(cmd, data)
 	}
 
 	return fmt.Errorf("command %d is not handled correctly", cmd)
@@ -148,4 +151,11 @@ func (h EmptyHandler) HandleStmtExecute(context interface{}, query string, args 
 
 func (h EmptyHandler) HandleStmtClose(context interface{}) error {
 	return nil
+}
+
+func (h EmptyHandler) HandleOtherCommand(cmd byte, data []byte) error {
+	return NewError(
+		ER_UNKNOWN_ERROR,
+		fmt.Sprintf("command %d is not supported now", cmd),
+	)
 }

--- a/server/command.go
+++ b/server/command.go
@@ -26,8 +26,7 @@ type Handler interface {
 	//this handler has no response
 	HandleStmtClose(context interface{}) error
 	//handle any other command that is not currently handled by the library,
-	//default implementation for this method should be:
-	//  return mysql.NewError(mysql.ER_UNKNOWN_ERROR, fmt.Sprintf("command %d is not supported now", cmd))
+	//default implementation for this method will return an ER_UNKNOWN_ERROR
 	HandleOtherCommand(cmd byte, data []byte) error
 }
 

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -1,0 +1,4 @@
+package server
+
+// Ensure EmptyHandler implements Handler interface or cause compile time error
+var _ Handler = EmptyHandler{}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -116,6 +116,10 @@ func (h *testHandler) HandleStmtExecute(ctx interface{}, query string, args []in
 	return h.handleQuery(query, true)
 }
 
+func (h *testHandler) HandleOtherCommand(cmd byte, data []byte) error {
+	return mysql.NewError(mysql.ER_UNKNOWN_ERROR, fmt.Sprintf("command %d is not supported now", cmd))
+}
+
 func (s *serverTestSuite) SetUpSuite(c *C) {
 	var err error
 


### PR DESCRIPTION
This PR extends `Handler` interface in the `server` package to have a method for handling commands not yet handled by the library.

This allows users of this library to implement extra functionality without extending `server` package. In my case I needed to handle `COM_REGISTER_SLAVE` and `COM_BINLOG_DUMP` commands which can not be easily handled by the `server` package itself.

This is straight forward implementation without caring about package backwards compatibility. If it is merged it will cause breakage for all existing `server` package users until they implement new method.

If breaking old clients is not acceptable we could:

- Create new interface `GenericHandler` with the new method, and try detect if given handler implements additional interface at runtime in `NewConn()`.
- Extend `server` package to have new constructor dedicated for handlers that implement extended interface.
- something else?