### PR TITLE
add mysqldump param --where

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -145,6 +145,7 @@ func (c *Canal) prepareDumper() error {
 	charset := c.cfg.Charset
 	c.dumper.SetCharset(charset)
 
+	c.dumper.SetWhere(c.cfg.Dump.Where)
 	c.dumper.SkipMasterData(c.cfg.Dump.SkipMasterData)
 	c.dumper.SetMaxAllowedPacket(c.cfg.Dump.MaxAllowedPacketMB)
 

--- a/canal/canal_test.go
+++ b/canal/canal_test.go
@@ -33,6 +33,7 @@ func (s *canalTestSuite) SetUpSuite(c *C) {
 	cfg.Dump.ExecutionPath = "mysqldump"
 	cfg.Dump.TableDB = "test"
 	cfg.Dump.Tables = []string{"canal_test"}
+	cfg.Dump.Where = "id>0"
 
 	// include & exclude config
 	cfg.IncludeTableRegex = make([]string, 1)

--- a/canal/config.go
+++ b/canal/config.go
@@ -24,6 +24,9 @@ type DumpConfig struct {
 	// Ignore table format is db.table
 	IgnoreTables []string `toml:"ignore_tables"`
 
+	// Dump only selected records. Quotes are mandatory
+	Where string `toml:"where"`
+
 	// If true, discard error msg, else, output to stderr
 	DiscardErr bool `toml:"discard_err"`
 

--- a/dump/dump.go
+++ b/dump/dump.go
@@ -108,6 +108,7 @@ func (d *Dumper) Reset() {
 	d.TableDB = ""
 	d.IgnoreTables = make(map[string][]string)
 	d.Databases = d.Databases[0:0]
+	d.Where = ""
 }
 
 func (d *Dumper) Dump(w io.Writer) error {

--- a/dump/dump.go
+++ b/dump/dump.go
@@ -26,6 +26,7 @@ type Dumper struct {
 
 	Databases []string
 
+	Where   string
 	Charset string
 
 	IgnoreTables map[string][]string
@@ -64,6 +65,10 @@ func NewDumper(executionPath string, addr string, user string, password string) 
 
 func (d *Dumper) SetCharset(charset string) {
 	d.Charset = charset
+}
+
+func (d *Dumper) SetWhere(where string) {
+	d.Where = where
 }
 
 func (d *Dumper) SetErrOut(o io.Writer) {
@@ -164,6 +169,10 @@ func (d *Dumper) Dump(w io.Writer) error {
 
 	if len(d.Charset) != 0 {
 		args = append(args, fmt.Sprintf("--default-character-set=%s", d.Charset))
+	}
+
+	if len(d.Where) != 0 {
+		args = append(args, fmt.Sprintf("--where=%s", d.Where))
 	}
 
 	cmd := exec.Command(d.ExecutionPath, args...)


### PR DESCRIPTION
Sometimes we only want to dump part of data of a single table, and we can use param "--where" to implement it.

```
./mysqldump
-w, --where=name    Dump only selected records. Quotes are mandatory.
```