### PR TITLE
Add Clone() method to mysql.GTIDSet

### DIFF
--- a/mysql/gtid.go
+++ b/mysql/gtid.go
@@ -13,6 +13,8 @@ type GTIDSet interface {
 	Contain(o GTIDSet) bool
 
 	Update(GTIDStr string) error
+
+	Clone() GTIDSet
 }
 
 func ParseGTIDSet(flavor string, s string) (GTIDSet, error) {

--- a/mysql/mariadb_gtid.go
+++ b/mysql/mariadb_gtid.go
@@ -89,3 +89,9 @@ func (gtid *MariadbGTID) Update(GTIDStr string) error {
 
 	return nil
 }
+
+func (gtid *MariadbGTID) Clone() GTIDSet {
+	clone := new(MariadbGTID)
+	*clone = *gtid
+	return clone
+}

--- a/mysql/mysql_gtid.go
+++ b/mysql/mysql_gtid.go
@@ -427,3 +427,9 @@ func (s *MysqlGTIDSet) Encode() []byte {
 
 	return buf.Bytes()
 }
+
+func (gtid *MysqlGTIDSet) Clone() GTIDSet {
+	clone := new(MysqlGTIDSet)
+	*clone = *gtid
+	return clone
+}


### PR DESCRIPTION
With the changes introduced in c6f8498, `ParseMariadbGTIDSet` now returns a `*MariadbGTID` (rather than `MariadbGTID`) wrapped in a `GTIDSet` interface. This fixed a bug around never incrementing the GTID; however, broke the way we store the GTID in various parts of our application as we expected the concrete type.

AFAIK Go does not expose an easy way to access the underlying value of an interface without making it less generic (i.e. casting the `GTIDSet` to either `*MysqlGTIDSet` or `*MariadbGTID`), so I propose adding a `Clone()` method to the `GTIDSet` interface to account for this change in behavior.

Currently, the only other option we have is to track the flavor of the GTID we're passing around and calling `ParseGTIDSet` to create a new one which is not ideal:

```go
clone, _ := mysql.ParseGTIDSet(flavor, gtid.String())
```