### PR TITLE
TWEAK: use gtid from dump position and binlog syncer

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -178,7 +178,7 @@ func (c *Canal) RunFrom(pos mysql.Position) error {
 }
 
 func (c *Canal) StartFromGTID(set mysql.GTIDSet) error {
-	c.master.UpdateGTID(set)
+	c.master.UpdateGTIDSet(set)
 
 	return c.Run()
 }
@@ -454,6 +454,6 @@ func (c *Canal) SyncedPosition() mysql.Position {
 	return c.master.Position()
 }
 
-func (c *Canal) SyncedGTID() mysql.GTIDSet {
-	return c.master.GTID()
+func (c *Canal) SyncedGTIDSet() mysql.GTIDSet {
+	return c.master.GTIDSet()
 }

--- a/canal/master.go
+++ b/canal/master.go
@@ -3,8 +3,8 @@ package canal
 import (
 	"sync"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/siddontang/go-mysql/mysql"
+	log "github.com/sirupsen/logrus"
 )
 
 type masterInfo struct {
@@ -12,7 +12,7 @@ type masterInfo struct {
 
 	pos mysql.Position
 
-	gtid mysql.GTIDSet
+	gset mysql.GTIDSet
 }
 
 func (m *masterInfo) Update(pos mysql.Position) {
@@ -23,11 +23,11 @@ func (m *masterInfo) Update(pos mysql.Position) {
 	m.Unlock()
 }
 
-func (m *masterInfo) UpdateGTID(gtid mysql.GTIDSet) {
-	log.Debugf("update master gtid %s", gtid.String())
+func (m *masterInfo) UpdateGTIDSet(gset mysql.GTIDSet) {
+	log.Debugf("update master gtid set %s", gset)
 
 	m.Lock()
-	m.gtid = gtid
+	m.gset = gset
 	m.Unlock()
 }
 
@@ -38,9 +38,9 @@ func (m *masterInfo) Position() mysql.Position {
 	return m.pos
 }
 
-func (m *masterInfo) GTID() mysql.GTIDSet {
+func (m *masterInfo) GTIDSet() mysql.GTIDSet {
 	m.RLock()
 	defer m.RUnlock()
 
-	return m.gtid
+	return m.gset
 }

--- a/dump/dump.go
+++ b/dump/dump.go
@@ -147,9 +147,6 @@ func (d *Dumper) Dump(w io.Writer) error {
 	// Multi row is easy for us to parse the data
 	args = append(args, "--skip-extended-insert")
 
-	// Disable gtid purge
-	args = append(args, "--set-gtid-purged=OFF")
-
 	for db, tables := range d.IgnoreTables {
 		for _, table := range tables {
 			args = append(args, fmt.Sprintf("--ignore-table=%s.%s", db, table))

--- a/dump/dump_test.go
+++ b/dump/dump_test.go
@@ -119,6 +119,10 @@ func (h *testParseHandler) BinLog(name string, pos uint64) error {
 	return nil
 }
 
+func (h *testParseHandler) GTIDSet(gset string) error {
+	return nil
+}
+
 func (h *testParseHandler) Data(schema string, table string, values []string) error {
 	return nil
 }
@@ -135,6 +139,28 @@ func (s *parserTestSuite) TestParseFindTable(c *C) {
 
 	for _, t := range tbl {
 		res := valuesExp.FindAllStringSubmatch(t.sql, -1)[0][1]
+		c.Assert(res, Equals, t.table)
+	}
+}
+
+func (s *parserTestSuite) TestParseGTIDPurge(c *C) {
+	tbl := []struct {
+		sql   string
+		table string
+	}{
+		{
+			// percona
+			"SET @@GLOBAL.GTID_PURGED='a4d0994c-4830-11e8-90a0-0242ac120005:1-3915';",
+			"a4d0994c-4830-11e8-90a0-0242ac120005:1-3915",
+		}, {
+			// mysql
+			"SET @@GLOBAL.GTID_PURGED=/*!80000 '+'*/ '8ab82362-9c37-11e7-a858-000c29c1025c:1-507455';",
+			"8ab82362-9c37-11e7-a858-000c29c1025c:1-507455",
+		},
+	}
+
+	for _, t := range tbl {
+		res := gtidExp.FindAllStringSubmatch(t.sql, -1)[0][1]
 		c.Assert(res, Equals, t.table)
 	}
 }

--- a/dump/parser.go
+++ b/dump/parser.go
@@ -19,16 +19,20 @@ var (
 type ParseHandler interface {
 	// Parse CHANGE MASTER TO MASTER_LOG_FILE=name, MASTER_LOG_POS=pos;
 	BinLog(name string, pos uint64) error
+	// Parse @@global.gtid_purged;
+	GTIDSet(gset string) error
 
 	Data(schema string, table string, values []string) error
 }
 
 var binlogExp *regexp.Regexp
+var gtidExp *regexp.Regexp
 var useExp *regexp.Regexp
 var valuesExp *regexp.Regexp
 
 func init() {
 	binlogExp = regexp.MustCompile("^CHANGE MASTER TO MASTER_LOG_FILE='(.+)', MASTER_LOG_POS=(\\d+);")
+	gtidExp = regexp.MustCompile("^SET @@GLOBAL\\.GTID_PURGED=.*'(.+)';")
 	useExp = regexp.MustCompile("^USE `(.+)`;")
 	valuesExp = regexp.MustCompile("^INSERT INTO `(.+?)` VALUES \\((.+)\\);$")
 }
@@ -67,6 +71,12 @@ func Parse(r io.Reader, h ParseHandler, parseBinlogPos bool) error {
 				}
 
 				binlogParsed = true
+			}
+		}
+
+		if m := gtidExp.FindAllStringSubmatch(line, -1); len(m) == 1 {
+			if err = h.GTIDSet(m[0][1]); err != nil && err != ErrSkip {
+				return errors.Trace(err)
 			}
 		}
 

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -334,7 +334,7 @@ func (b *BinlogSyncer) StartSync(pos Position) (*BinlogStreamer, error) {
 
 // StartSyncGTID starts syncing from the `gset` GTIDSet.
 func (b *BinlogSyncer) StartSyncGTID(gset GTIDSet) (*BinlogStreamer, error) {
-	log.Infof("begin to sync binlog from GTID %s", gset)
+	log.Infof("begin to sync binlog from GTID set %s", gset)
 
 	b.gset = gset
 


### PR DESCRIPTION
This is an improvement/bugfix to the previous PR.

1. In the prev PR, we continue with file-based binlog replication from gtid dump, and that introduces a special case. Instead, we can use global.gtid_purged.

1. Reimplement `SyncedGTIDSet` because one single gtid is generally useless to restore sync from. 

1. Renaming some `gtid` to `gset`, which is a set of gtid, to be clear