### PR TITLE
Fix replication of TIMESTAMP on non-UTC machines

### DIFF
--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -57,6 +57,20 @@ type BinlogSyncerConfig struct {
 	// We will use Local location for timestamp and UTC location for datatime.
 	ParseTime bool
 
+	// If ParseTime is false, convert TIMESTAMP into this specified timezone. If
+	// ParseTime is true, this option will have no effect and TIMESTAMP data will
+	// be parsed into the local timezone and a full time.Time struct will be
+	// returned.
+	//
+	// Note that MySQL TIMESTAMP columns are offset from the machine local
+	// timezone while DATETIME columns are offset from UTC. This is consistent
+	// with documented MySQL behaviour as it return TIMESTAMP in local timezone
+	// and DATETIME in UTC.
+	//
+	// Setting this to UTC effectively equalizes the TIMESTAMP and DATETIME time
+	// strings obtained from MySQL.
+	TimestampStringLocation *time.Location
+
 	// Use decimal.Decimal structure for decimals.
 	UseDecimal bool
 
@@ -124,6 +138,7 @@ func NewBinlogSyncer(cfg BinlogSyncerConfig) *BinlogSyncer {
 	b.parser = NewBinlogParser()
 	b.parser.SetRawMode(b.cfg.RawModeEnabled)
 	b.parser.SetParseTime(b.cfg.ParseTime)
+	b.parser.SetTimestampStringLocation(b.cfg.TimestampStringLocation)
 	b.parser.SetUseDecimal(b.cfg.UseDecimal)
 	b.parser.SetVerifyChecksum(b.cfg.VerifyChecksum)
 	b.running = false

--- a/replication/parser.go
+++ b/replication/parser.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"sync/atomic"
+	"time"
 
 	"github.com/juju/errors"
 )
@@ -25,7 +26,8 @@ type BinlogParser struct {
 	// for rawMode, we only parse FormatDescriptionEvent and RotateEvent
 	rawMode bool
 
-	parseTime bool
+	parseTime               bool
+	timestampStringLocation *time.Location
 
 	// used to start/stop processing
 	stopProcessing uint32
@@ -181,6 +183,10 @@ func (p *BinlogParser) SetRawMode(mode bool) {
 
 func (p *BinlogParser) SetParseTime(parseTime bool) {
 	p.parseTime = parseTime
+}
+
+func (p *BinlogParser) SetTimestampStringLocation(timestampStringLocation *time.Location) {
+	p.timestampStringLocation = timestampStringLocation
 }
 
 func (p *BinlogParser) SetUseDecimal(useDecimal bool) {
@@ -347,6 +353,7 @@ func (p *BinlogParser) newRowsEvent(h *EventHeader) *RowsEvent {
 	e.needBitmap2 = false
 	e.tables = p.tables
 	e.parseTime = p.parseTime
+	e.timestampStringLocation = p.timestampStringLocation
 	e.useDecimal = p.useDecimal
 
 	switch h.EventType {

--- a/replication/time.go
+++ b/replication/time.go
@@ -16,10 +16,16 @@ type fracTime struct {
 
 	// Dec must in [0, 6]
 	Dec int
+
+	timestampStringLocation *time.Location
 }
 
 func (t fracTime) String() string {
-	return t.Format(fracTimeFormat[t.Dec])
+	tt := t.Time
+	if t.timestampStringLocation != nil {
+		tt = tt.In(t.timestampStringLocation)
+	}
+	return tt.Format(fracTimeFormat[t.Dec])
 }
 
 func formatZeroTime(frac int, dec int) string {

--- a/replication/time_test.go
+++ b/replication/time_test.go
@@ -10,7 +10,7 @@ type testTimeSuite struct{}
 
 var _ = Suite(&testTimeSuite{})
 
-func (s *testSyncerSuite) TestTime(c *C) {
+func (s *testTimeSuite) TestTime(c *C) {
 	tbls := []struct {
 		year     int
 		month    int
@@ -28,7 +28,7 @@ func (s *testSyncerSuite) TestTime(c *C) {
 	}
 
 	for _, t := range tbls {
-		t1 := fracTime{time.Date(t.year, time.Month(t.month), t.day, t.hour, t.min, t.sec, t.microSec*1000, time.UTC), t.frac}
+		t1 := fracTime{time.Date(t.year, time.Month(t.month), t.day, t.hour, t.min, t.sec, t.microSec*1000, time.UTC), t.frac, nil}
 		c.Assert(t1.String(), Equals, t.expected)
 	}
 
@@ -49,3 +49,22 @@ func (s *testSyncerSuite) TestTime(c *C) {
 		c.Assert(formatZeroTime(t.frac, t.dec), Equals, t.expected)
 	}
 }
+
+func (s *testTimeSuite) TestTimeStringLocation(c *C) {
+	t := fracTime{
+		time.Date(2018, time.Month(7), 30, 10, 0, 0, 0, time.FixedZone("EST", -5*3600)),
+		0,
+		nil,
+	}
+
+	c.Assert(t.String(), Equals, "2018-07-30 10:00:00")
+
+	t = fracTime{
+		time.Date(2018, time.Month(7), 30, 10, 0, 0, 0, time.FixedZone("EST", -5*3600)),
+		0,
+		time.UTC,
+	}
+	c.Assert(t.String(), Equals, "2018-07-30 15:00:00")
+}
+
+var _ = Suite(&testTimeSuite{})


### PR DESCRIPTION
To get the timestamp in any timezone, in the codebase consuming this library, add (and substitute with the timezone of your choice):

```
func init() {
	replication.TimeStringLocation = time.UTC
}
```

Fixes: #63 

Also see: github/gh-ost#182 and Shopify/ghostferry#23

review: @siddontang 