### PR TITLE
add an option to verify binlog checksum

### DIFF
--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -71,6 +71,8 @@ type BinlogSyncerConfig struct {
 
 	// maximum number of attempts to re-establish a broken connection
 	MaxReconnectAttempts int
+
+	VerifyChecksum bool
 }
 
 // BinlogSyncer syncs binlog event from server.
@@ -118,6 +120,7 @@ func NewBinlogSyncer(cfg BinlogSyncerConfig) *BinlogSyncer {
 	b.parser.SetRawMode(b.cfg.RawModeEnabled)
 	b.parser.SetParseTime(b.cfg.ParseTime)
 	b.parser.SetUseDecimal(b.cfg.UseDecimal)
+	b.parser.SetVerifyChecksum(b.cfg.VerifyChecksum)
 	b.running = false
 	b.ctx, b.cancel = context.WithCancel(context.Background())
 

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -72,6 +72,11 @@ type BinlogSyncerConfig struct {
 	// maximum number of attempts to re-establish a broken connection
 	MaxReconnectAttempts int
 
+	// Only works when MySQL/MariaDB variable binlog_checksum=CRC32.
+	// For MySQL, binlog_checksum was introduced since 5.6.2, but CRC32 was set as default value since 5.6.6 .
+	// https://dev.mysql.com/doc/refman/5.6/en/replication-options-binary-log.html#option_mysqld_binlog-checksum
+	// For MariaDB, binlog_checksum was introduced since MariaDB 5.3, but CRC32 was set as default value since MariaDB 10.2.1 .
+	// https://mariadb.com/kb/en/library/replication-and-binary-log-server-system-variables/#binlog_checksum
 	VerifyChecksum bool
 }
 

--- a/replication/event.go
+++ b/replication/event.go
@@ -2,7 +2,6 @@ package replication
 
 import (
 	"encoding/binary"
-	//"encoding/hex"
 	"fmt"
 	"io"
 	"strconv"
@@ -20,6 +19,7 @@ const (
 	SidLength                  = 16
 	LogicalTimestampTypeCode   = 2
 	PartLogicalTimestampLength = 8
+	BinlogChecksumLength       = 4
 )
 
 type BinlogEvent struct {

--- a/replication/parser.go
+++ b/replication/parser.go
@@ -324,6 +324,9 @@ func (p *BinlogParser) verifyCrc32Checksum(rawData []byte) error {
 	calculatedPart := rawData[0 : len(rawData)-BinlogChecksumLength]
 	expectedChecksum := rawData[len(rawData)-BinlogChecksumLength:]
 
+	// mysql use zlib's CRC32 implementation, which uses polynomial 0xedb88320UL.
+	// reference: https://github.com/madler/zlib/blob/master/crc32.c
+	// https://github.com/madler/zlib/blob/master/doc/rfc1952.txt#L419
 	checksum := crc32.ChecksumIEEE(calculatedPart)
 	computed := make([]byte, BinlogChecksumLength)
 	binary.LittleEndian.PutUint32(computed, checksum)

--- a/replication/parser.go
+++ b/replication/parser.go
@@ -2,12 +2,19 @@ package replication
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"os"
 	"sync/atomic"
 
 	"github.com/juju/errors"
+)
+
+var (
+	// ErrChecksumMismatch indicates binlog checksum mismatch.
+	ErrChecksumMismatch = errors.New("binlog checksum mismatch, data may be corrupted")
 )
 
 type BinlogParser struct {
@@ -23,14 +30,14 @@ type BinlogParser struct {
 	// used to start/stop processing
 	stopProcessing uint32
 
-	useDecimal bool
+	useDecimal     bool
+	verifyChecksum bool
 }
 
 func NewBinlogParser() *BinlogParser {
 	p := new(BinlogParser)
 
 	p.tables = make(map[uint64]*TableMapEvent)
-	// p.stop = make(uint32)
 
 	return p
 }
@@ -130,7 +137,7 @@ func (p *BinlogParser) parseSingleEvent(r io.Reader, onEvent OnEventFunc) (bool,
 	}
 
 	var e Event
-	e, err = p.parseEvent(h, data)
+	e, err = p.parseEvent(h, data, rawData)
 	if err != nil {
 		if _, ok := err.(errMissingTableMapEvent); ok {
 			return false, nil
@@ -180,6 +187,10 @@ func (p *BinlogParser) SetUseDecimal(useDecimal bool) {
 	p.useDecimal = useDecimal
 }
 
+func (p *BinlogParser) SetVerifyChecksum(verify bool) {
+	p.verifyChecksum = verify
+}
+
 func (p *BinlogParser) parseHeader(data []byte) (*EventHeader, error) {
 	h := new(EventHeader)
 	err := h.Decode(data)
@@ -190,7 +201,7 @@ func (p *BinlogParser) parseHeader(data []byte) (*EventHeader, error) {
 	return h, nil
 }
 
-func (p *BinlogParser) parseEvent(h *EventHeader, data []byte) (Event, error) {
+func (p *BinlogParser) parseEvent(h *EventHeader, data []byte, rawData []byte) (Event, error) {
 	var e Event
 
 	if h.EventType == FORMAT_DESCRIPTION_EVENT {
@@ -198,7 +209,11 @@ func (p *BinlogParser) parseEvent(h *EventHeader, data []byte) (Event, error) {
 		e = p.format
 	} else {
 		if p.format != nil && p.format.ChecksumAlgorithm == BINLOG_CHECKSUM_ALG_CRC32 {
-			data = data[0 : len(data)-4]
+			err := p.verifyCrc32Checksum(rawData)
+			if err != nil {
+				return nil, err
+			}
+			data = data[0 : len(data)-BinlogChecksumLength]
 		}
 
 		if h.EventType == ROTATE_EVENT {
@@ -293,12 +308,29 @@ func (p *BinlogParser) Parse(data []byte) (*BinlogEvent, error) {
 		return nil, fmt.Errorf("invalid data size %d in event %s, less event length %d", len(data), h.EventType, eventLen)
 	}
 
-	e, err := p.parseEvent(h, data)
+	e, err := p.parseEvent(h, data, rawData)
 	if err != nil {
 		return nil, err
 	}
 
 	return &BinlogEvent{rawData, h, e}, nil
+}
+
+func (p *BinlogParser) verifyCrc32Checksum(rawData []byte) error {
+	if !p.verifyChecksum {
+		return nil
+	}
+
+	calculatedPart := rawData[0 : len(rawData)-BinlogChecksumLength]
+	expectedChecksum := rawData[len(rawData)-BinlogChecksumLength:]
+
+	checksum := crc32.ChecksumIEEE(calculatedPart)
+	computed := make([]byte, BinlogChecksumLength)
+	binary.LittleEndian.PutUint32(computed, checksum)
+	if !bytes.Equal(expectedChecksum, computed) {
+		return ErrChecksumMismatch
+	}
+	return nil
 }
 
 func (p *BinlogParser) newRowsEvent(h *EventHeader) *RowsEvent {


### PR DESCRIPTION
Add an option to verify binlog checksum, and disabled by default, so same behaviour as before.
The user can use `BinlogSyncerConfig.VerifyChecksum` to enable verification.

For MySQL, binlog checksum was introduced since 5.6.2, so before 5.6.2, the value of `FormatDescriptionEvent.ChecksumAlgorithm` is `BINLOG_CHECKSUM_ALG_UNDEF`(undefined).

For MariaDB,
>Checksums are enabled with the binlog_checksum option. Until MariaDB 10.2.1, this was disabled by default. From MariaDB 10.2.1, the option is set to CRC32.

So only when `binlog_checksum = CRC32` and `BinlogSyncerConfig.VerifyChecksum = true` will it works.

@siddontang  @GregoryIan   PTAL 