### PR TITLE
Add Int24, Uint24 type

### DIFF
--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -139,13 +139,13 @@ func (t *mysqlTestSuite) TestMysqlParseBinaryUint16(c *check.C) {
 }
 
 func (t *mysqlTestSuite) TestMysqlParseBinaryInt24(c *check.C) {
-	i32 := ParseBinaryInt24([]byte{1, 2, 128})
-	c.Assert(i32, check.Equals, int32(-128*65536+2*256+1))
+	i24 := ParseBinaryInt24([]byte{1, 2, 128})
+	c.Assert(i24, check.Equals, Int24(-128*65536+2*256+1))
 }
 
 func (t *mysqlTestSuite) TestMysqlParseBinaryUint24(c *check.C) {
-	u32 := ParseBinaryUint24([]byte{1, 2, 128})
-	c.Assert(u32, check.Equals, uint32(128*65536+2*256+1))
+	u24 := ParseBinaryUint24([]byte{1, 2, 128})
+	c.Assert(u24, check.Equals, Uint24(128*65536+2*256+1))
 }
 
 func (t *mysqlTestSuite) TestMysqlParseBinaryInt32(c *check.C) {

--- a/mysql/parse_binary.go
+++ b/mysql/parse_binary.go
@@ -19,15 +19,38 @@ func ParseBinaryUint16(data []byte) uint16 {
 	return binary.LittleEndian.Uint16(data)
 }
 
-func ParseBinaryInt24(data []byte) int32 {
+type Int24 int32
+
+func (v Int24) ToInt32() int32 {
+	return int32(v)
+}
+func (v Int24) ToUint24() Uint24 {
+	data := make([]byte, 4)
+	binary.LittleEndian.PutUint32(data, uint32(v.ToInt32()))
+	return Uint24(data[0]) | Uint24(data[1])<<8 | Uint24(data[2])<<16
+}
+
+type Uint24 uint32
+
+func (v Uint24) ToUint32() uint32 {
+	return uint32(v)
+}
+func (v Uint24) ToInt24() Int24 {
+	if v&0x00800000 != 0 {
+		v |= 0xFF000000
+	}
+	return Int24(v)
+}
+
+func ParseBinaryInt24(data []byte) Int24 {
 	u32 := uint32(ParseBinaryUint24(data))
 	if u32&0x00800000 != 0 {
 		u32 |= 0xFF000000
 	}
-	return int32(u32)
+	return Int24(u32)
 }
-func ParseBinaryUint24(data []byte) uint32 {
-	return uint32(data[0]) | uint32(data[1])<<8 | uint32(data[2])<<16
+func ParseBinaryUint24(data []byte) Uint24 {
+	return Uint24(data[0]) | Uint24(data[1])<<8 | Uint24(data[2])<<16
 }
 
 func ParseBinaryInt32(data []byte) int32 {


### PR DESCRIPTION
now, for MySQL's MEDIUMINT, we use int32 / uint32 to store it in `RowsEvent.Rows`.

When the raw data is unsigned MEDIUMINT, we store data in `RowsEvent.Rows` use int32, and store `unsigned` info in table structure.

But now, we will treat it as uint32 rather than uint24 (although no this type).

so, when we convert int32 value like `-4692783` to uint24 (unsigned MEDIUMINT), it will be `4290274513` (uint32), but we expected is `12084433` (uint24)

to correct this, we have to methods:
1. retrieve unsinged `MEDIUMINT` from table structure, and convert it to **3 bit valid** uint32
2. add `Int24`, `Uint24` types, store the data in `RowsEvent.Rows` as `Int24`, and convert it to `Uint24`

in this PR, I chose to add `Int24`, `Uint24` types

@siddontang @GregoryIan @holys  PTAL