### PR TITLE
fix error checking and rawData in parseSingleEvent function

### DIFF
--- a/replication/parser.go
+++ b/replication/parser.go
@@ -128,12 +128,16 @@ func (p *BinlogParser) parseSingleEvent(r io.Reader, onEvent OnEventFunc) (bool,
 	}
 
 	data := buf.Bytes()
-	rawData := data
-
 	eventLen := int(h.EventSize) - EventHeaderSize
-
 	if len(data) != eventLen {
-		return false, errors.Errorf("invalid data size %d in event %s, less event length %d", len(data), h.EventType, eventLen)
+		return false, errors.Errorf("invalid data size %d in event %s, not equal to event length %d", len(data), h.EventType, eventLen)
+	}
+
+	rawData := make([]byte, h.EventSize)
+	copy(rawData[0:EventHeaderSize], headBuf)
+	copy(rawData[EventHeaderSize:], data)
+	if len(rawData) != int(h.EventSize) {
+		return false, errors.Errorf("invalid raw data size %d in event %s, not equal to event length %d", len(rawData), h.EventType, h.EventSize)
 	}
 
 	var e Event

--- a/replication/parser.go
+++ b/replication/parser.go
@@ -139,7 +139,7 @@ func (p *BinlogParser) parseSingleEvent(r io.Reader, onEvent OnEventFunc) (bool,
 	var e Event
 	e, err = p.parseEvent(h, data, rawData)
 	if err != nil {
-		if _, ok := err.(errMissingTableMapEvent); ok {
+		if err == errMissingTableMapEvent {
 			return false, nil
 		}
 		return false, errors.Trace(err)
@@ -161,7 +161,7 @@ func (p *BinlogParser) ParseReader(r io.Reader, onEvent OnEventFunc) error {
 
 		done, err := p.parseSingleEvent(r, onEvent)
 		if err != nil {
-			if _, ok := err.(errMissingTableMapEvent); ok {
+			if err == errMissingTableMapEvent {
 				continue
 			}
 			return errors.Trace(err)

--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -16,7 +16,7 @@ import (
 	"github.com/siddontang/go/hack"
 )
 
-type errMissingTableMapEvent error
+var errMissingTableMapEvent = errors.New("invalid table id, no corresponding table map event")
 
 type TableMapEvent struct {
 	tableIDSize int
@@ -266,7 +266,7 @@ func (e *RowsEvent) Decode(data []byte) error {
 		if len(e.tables) > 0 {
 			return errors.Errorf("invalid table id %d, no corresponding table map event", e.TableID)
 		} else {
-			return errMissingTableMapEvent(errors.Errorf("invalid table id %d, no corresponding table map event", e.TableID))
+			return errors.Annotatef(errMissingTableMapEvent, "table id %d", e.TableID)
 		}
 	}
 


### PR DESCRIPTION
1. the previous of checking errMissingTableMapEvent is wrong, and it won't works.
2. rawData in parseSingleEvent function doesn't contain the header part, but we should include the header.

@siddontang  PTAL