### PR TITLE
canal: Add ParseTime config option

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -417,6 +417,7 @@ func (c *Canal) prepareSyncer() error {
 		HeartbeatPeriod: c.cfg.HeartbeatPeriod,
 		ReadTimeout:     c.cfg.ReadTimeout,
 		UseDecimal:      c.cfg.UseDecimal,
+		ParseTime:       c.cfg.ParseTime,
 		SemiSyncEnabled: c.cfg.SemiSyncEnabled,
 	}
 

--- a/canal/config.go
+++ b/canal/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	Dump DumpConfig `toml:"dump"`
 
 	UseDecimal bool `toml:"use_decimal"`
+	ParseTime bool  `toml:"parse_time"`
 
 	// SemiSyncEnabled enables semi-sync or not.
 	SemiSyncEnabled bool `toml:"semi_sync_enabled"`


### PR DESCRIPTION
Default is to convert timestamps to string. This is a lossy conversion even
if the timezone is known as DTS information gets lost.

By passing ParseTime to go-mysql/replication, the unix timestamp from the DB
is converted to time.Time. From there, the original timestamp can be retrieved.