### PR TITLE
row_event.go: fix the set bytes value in revert order

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -91,7 +91,7 @@ func (s *clientTestSuite) TestConn_TLS(c *C) {
 
 	expected := "either ServerName or InsecureSkipVerify must be specified in the tls.Config"
 	if !strings.Contains(err.Error(), expected) {
-		c.Fatal("expected '%s' to contain '%s'", err.Error(), expected)
+		c.Fatalf("expected '%s' to contain '%s'", err.Error(), expected)
 	}
 }
 

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -270,7 +270,7 @@ func (b *BinlogSyncer) registerSlave() error {
 	if b.cfg.HeartbeatPeriod > 0 {
 		_, err = b.c.Execute(fmt.Sprintf("SET @master_heartbeat_period=%d;", b.cfg.HeartbeatPeriod))
 		if err != nil {
-			log.Error("failed to set @master_heartbeat_period=%d", b.cfg.HeartbeatPeriod, err)
+			log.Errorf("failed to set @master_heartbeat_period=%d, err: %v", b.cfg.HeartbeatPeriod, err)
 			return errors.Trace(err)
 		}
 	}

--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -490,7 +490,7 @@ func (e *RowsEvent) decodeValue(data []byte, tp byte, meta uint16) (v interface{
 			v = int64(data[0])
 			n = 1
 		case 2:
-			v = int64(binary.BigEndian.Uint16(data))
+			v = int64(binary.LittleEndian.Uint16(data))
 			n = 2
 		default:
 			err = fmt.Errorf("Unknown ENUM packlen=%d", l)

--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -424,8 +424,8 @@ func (e *RowsEvent) decodeValue(data []byte, tp byte, meta uint16) (v interface{
 			v = formatZeroTime(0, 0)
 		} else {
 			v = e.parseFracTime(fracTime{
-				Time: time.Unix(int64(t), 0),
-				Dec:  0,
+				Time:                    time.Unix(int64(t), 0),
+				Dec:                     0,
 				timestampStringLocation: e.timestampStringLocation,
 			})
 		}
@@ -499,7 +499,7 @@ func (e *RowsEvent) decodeValue(data []byte, tp byte, meta uint16) (v interface{
 		n = int(meta & 0xFF)
 		nbits := n * 8
 
-		v, err = decodeBit(data, nbits, n)
+		v, err = littleDecodeBit(data, nbits, n)
 	case MYSQL_TYPE_BLOB:
 		v, n, err = decodeBlob(data, meta)
 	case MYSQL_TYPE_VARCHAR,
@@ -650,6 +650,38 @@ func decodeBit(data []byte, nbits int, length int) (value int64, err error) {
 	return
 }
 
+func littleDecodeBit(data []byte, nbits int, length int) (value int64, err error) {
+	if nbits > 1 {
+		switch length {
+		case 1:
+			value = int64(data[0])
+		case 2:
+			value = int64(binary.LittleEndian.Uint16(data))
+		case 3:
+			value = int64(FixedLengthInt(data[0:3]))
+		case 4:
+			value = int64(binary.LittleEndian.Uint32(data))
+		case 5:
+			value = int64(FixedLengthInt(data[0:5]))
+		case 6:
+			value = int64(FixedLengthInt(data[0:6]))
+		case 7:
+			value = int64(FixedLengthInt(data[0:7]))
+		case 8:
+			value = int64(binary.LittleEndian.Uint64(data))
+		default:
+			err = fmt.Errorf("invalid bit length %d", length)
+		}
+	} else {
+		if length != 1 {
+			err = fmt.Errorf("invalid bit length %d", length)
+		} else {
+			value = int64(data[0])
+		}
+	}
+	return
+}
+
 func decodeTimestamp2(data []byte, dec uint16, timestampStringLocation *time.Location) (interface{}, int, error) {
 	//get timestamp binary length
 	n := int(4 + (dec+1)/2)
@@ -669,8 +701,8 @@ func decodeTimestamp2(data []byte, dec uint16, timestampStringLocation *time.Loc
 	}
 
 	return fracTime{
-		Time: time.Unix(sec, usec*1000),
-		Dec:  int(dec),
+		Time:                    time.Unix(sec, usec*1000),
+		Dec:                     int(dec),
 		timestampStringLocation: timestampStringLocation,
 	}, n, nil
 }


### PR DESCRIPTION
fix https://github.com/pingcap/tidb-tools/issues/70

according to the binlog, we should handle it in little end 
i have test more when the set num is 18 (need 3 bytes), but i can't find a doc from mysql about this