### PR TITLE
Update parser.go add the parse code  for ANONYMOUS_GTID_EVENT

### DIFF
--- a/replication/parser.go
+++ b/replication/parser.go
@@ -250,6 +250,8 @@ func (p *BinlogParser) parseEvent(h *EventHeader, data []byte, rawData []byte) (
 				e = &RowsQueryEvent{}
 			case GTID_EVENT:
 				e = &GTIDEvent{}
+			case ANONYMOUS_GTID_EVENT:
+				e = &GTIDEvent{}	
 			case BEGIN_LOAD_QUERY_EVENT:
 				e = &BeginLoadQueryEvent{}
 			case EXECUTE_LOAD_QUERY_EVENT:


### PR DESCRIPTION
As we know , In MySQL 5.7.x ， it support the table level MTS known as Logical clock . And the parallel information in the GTID_EVENT , if  we use GTID replication. If we set the gtid_mode off , There will have a Anonymous_Gtid Event for the parallel information。 The ANONYMOUS_GTID_EVENT and GTID_EVENT has the same structure.  So I add the parse logic in parser.go for it . 

We can do more thing if we can get the parallel information. 