### PR TITLE
Setting --column-statistics=0 on dump

### DIFF
--- a/dump/dump.go
+++ b/dump/dump.go
@@ -147,6 +147,10 @@ func (d *Dumper) Dump(w io.Writer) error {
 	args = append(args, "--skip-opt")
 	args = append(args, "--quick")
 
+	// Disable --column-statistics casue default behavior changes in mysqldump 8.0
+	// This can cause this problem https://serverfault.com/questions/912162/mysqldump-throws-unknown-table-column-statistics-in-information-schema-1109
+	args = append(args, "--column-statistics=0")
+
 	// We only care about data
 	args = append(args, "--no-create-info")
 


### PR DESCRIPTION
Hey,

I have been using your library. But got into some problems cause I have the mysqldump 8.0 installed.
They have changed the default for `--column-statistics` to 1 and at least when running AWS Aurora MySql, I'm getting into this problem: https://serverfault.com/questions/912162/mysqldump-throws-unknown-table-column-statistics-in-information-schema-1109

And I think we don't need to have `--column-statisictis` enabled.

From the mysql docs:
```
--column-statistics

Add ANALYZE TABLE statements to the output to generate histogram statistics for dumped tables when the dump file is reloaded. This option is disabled by default because histogram generation for large tables can take a long time.
```
https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_column-statistics