### PR TITLE
Fixes and improvements for replication

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -200,6 +200,8 @@ func (c *Canal) run() error {
 		c.cancel()
 	}()
 
+	c.master.UpdateTimestamp(uint32(time.Now().Unix()))
+
 	if !c.dumped {
 		c.dumped = true
 
@@ -456,6 +458,10 @@ func (c *Canal) Execute(cmd string, args ...interface{}) (rr *mysql.Result, err 
 
 func (c *Canal) SyncedPosition() mysql.Position {
 	return c.master.Position()
+}
+
+func (c *Canal) SyncedTimestamp() uint32 {
+	return c.master.timestamp
 }
 
 func (c *Canal) SyncedGTIDSet() mysql.GTIDSet {

--- a/canal/dump.go
+++ b/canal/dump.go
@@ -50,6 +50,8 @@ func (h *dumpParseHandler) Data(db string, table string, values []string) error 
 	for i, v := range values {
 		if v == "NULL" {
 			vs[i] = nil
+		} else if v == "_binary ''" {
+			vs[i] = []byte{}
 		} else if v[0] != '\'' {
 			if tableInfo.Columns[i].Type == schema.TYPE_NUMBER {
 				n, err := strconv.ParseInt(v, 10, 64)

--- a/canal/dump.go
+++ b/canal/dump.go
@@ -132,6 +132,8 @@ func (c *Canal) dump() error {
 		return errors.New("mysqldump does not exist")
 	}
 
+	c.master.UpdateTimestamp(uint32(time.Now().Unix()))
+
 	h := &dumpParseHandler{c: c}
 	// If users call StartFromGTID with empty position to start dumping with gtid,
 	// we record the current gtid position before dump starts.

--- a/canal/dump.go
+++ b/canal/dump.go
@@ -163,7 +163,9 @@ func (c *Canal) dump() error {
 
 	pos := mysql.Position{h.name, uint32(h.pos)}
 	c.master.Update(pos)
-	c.eventHandler.OnPosSynced(pos, true)
+	if err := c.eventHandler.OnPosSynced(pos, true); err != nil {
+		return errors.Trace(err)
+	}
 	var startPos fmt.Stringer = pos
 	if h.gset != nil {
 		c.master.UpdateGTIDSet(h.gset)

--- a/canal/dump.go
+++ b/canal/dump.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/shopspring/decimal"
 	"github.com/siddontang/go-log/log"
-	"github.com/siddontang/go-mysql/dump"
 	"github.com/siddontang/go-mysql/mysql"
 	"github.com/siddontang/go-mysql/schema"
 )
@@ -56,43 +55,37 @@ func (h *dumpParseHandler) Data(db string, table string, values []string) error 
 			if tableInfo.Columns[i].Type == schema.TYPE_NUMBER {
 				n, err := strconv.ParseInt(v, 10, 64)
 				if err != nil {
-					log.Errorf("parse row %v at %d error %v, skip", values, i, err)
-					return dump.ErrSkip
+					return fmt.Errorf("parse row %v at %d error %v, int expected", values, i, err)
 				}
 				vs[i] = n
 			} else if tableInfo.Columns[i].Type == schema.TYPE_FLOAT {
 				f, err := strconv.ParseFloat(v, 64)
 				if err != nil {
-					log.Errorf("parse row %v at %d error %v, skip", values, i, err)
-					return dump.ErrSkip
+					return fmt.Errorf("parse row %v at %d error %v, float expected", values, i, err)
 				}
 				vs[i] = f
 			} else if tableInfo.Columns[i].Type == schema.TYPE_DECIMAL {
 				if h.c.cfg.UseDecimal {
 					d, err := decimal.NewFromString(v)
 					if err != nil {
-						log.Errorf("parse row %v at %d error %v, skip", values, i, err)
-						return dump.ErrSkip
+						return fmt.Errorf("parse row %v at %d error %v, decimal expected", values, i, err)
 					}
 					vs[i] = d
 				} else {
 					f, err := strconv.ParseFloat(v, 64)
 					if err != nil {
-						log.Errorf("parse row %v at %d error %v, skip", values, i, err)
-						return dump.ErrSkip
+						return fmt.Errorf("parse row %v at %d error %v, float expected", values, i, err)
 					}
 					vs[i] = f
 				}
 			} else if strings.HasPrefix(v, "0x") {
 				buf, err := hex.DecodeString(v[2:])
 				if err != nil {
-					log.Errorf("parse row %v at %d error %v, skip", values, i, err)
-					return dump.ErrSkip
+					return fmt.Errorf("parse row %v at %d error %v, hex literal expected", values, i, err)
 				}
 				vs[i] = string(buf)
 			} else {
-				log.Errorf("parse row %v error, invalid type at %d, skip", values, i)
-				return dump.ErrSkip
+				return fmt.Errorf("parse row %v error, invalid type at %d", values, i)
 			}
 		} else {
 			vs[i] = v[1 : len(v)-1]

--- a/canal/master.go
+++ b/canal/master.go
@@ -13,6 +13,8 @@ type masterInfo struct {
 	pos mysql.Position
 
 	gset mysql.GTIDSet
+
+	timestamp uint32
 }
 
 func (m *masterInfo) Update(pos mysql.Position) {
@@ -20,6 +22,14 @@ func (m *masterInfo) Update(pos mysql.Position) {
 
 	m.Lock()
 	m.pos = pos
+	m.Unlock()
+}
+
+func (m *masterInfo) UpdateTimestamp(ts uint32) {
+	log.Debugf("update master timestamp %s", ts)
+
+	m.Lock()
+	m.timestamp = ts
 	m.Unlock()
 }
 
@@ -36,6 +46,13 @@ func (m *masterInfo) Position() mysql.Position {
 	defer m.RUnlock()
 
 	return m.pos
+}
+
+func (m *masterInfo) Timestamp() uint32 {
+	m.RLock()
+	defer m.RUnlock()
+
+	return m.timestamp
 }
 
 func (m *masterInfo) GTIDSet() mysql.GTIDSet {

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -164,7 +164,9 @@ func (c *Canal) runSyncBinlog() error {
 
 		if savePos {
 			c.master.Update(pos)
-			c.eventHandler.OnPosSynced(pos, force)
+			if err := c.eventHandler.OnPosSynced(pos, force); err != nil {
+				return errors.Trace(err)
+			}
 		}
 	}
 

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -164,6 +164,7 @@ func (c *Canal) runSyncBinlog() error {
 
 		if savePos {
 			c.master.Update(pos)
+			c.master.UpdateTimestamp(ev.Header.Timestamp)
 			if err := c.eventHandler.OnPosSynced(pos, force); err != nil {
 				return errors.Trace(err)
 			}

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -14,10 +14,11 @@ import (
 )
 
 var (
-	expCreateTable = regexp.MustCompile("(?i)^CREATE\\sTABLE(\\sIF\\sNOT\\sEXISTS)?\\s`{0,1}(.*?)`{0,1}\\.{0,1}`{0,1}([^`\\.]+?)`{0,1}\\s.*")
-	expAlterTable  = regexp.MustCompile("(?i)^ALTER\\sTABLE\\s.*?`{0,1}(.*?)`{0,1}\\.{0,1}`{0,1}([^`\\.]+?)`{0,1}\\s.*")
-	expRenameTable = regexp.MustCompile("(?i)^RENAME\\sTABLE\\s.*?`{0,1}(.*?)`{0,1}\\.{0,1}`{0,1}([^`\\.]+?)`{0,1}\\s{1,}TO\\s.*?")
-	expDropTable   = regexp.MustCompile("(?i)^DROP\\sTABLE(\\sIF\\sEXISTS){0,1}\\s`{0,1}(.*?)`{0,1}\\.{0,1}`{0,1}([^`\\.]+?)`{0,1}(?:$|\\s)")
+	expCreateTable   = regexp.MustCompile("(?i)^CREATE\\sTABLE(\\sIF\\sNOT\\sEXISTS)?\\s`{0,1}(.*?)`{0,1}\\.{0,1}`{0,1}([^`\\.]+?)`{0,1}\\s.*")
+	expAlterTable    = regexp.MustCompile("(?i)^ALTER\\sTABLE\\s.*?`{0,1}(.*?)`{0,1}\\.{0,1}`{0,1}([^`\\.]+?)`{0,1}\\s.*")
+	expRenameTable   = regexp.MustCompile("(?i)^RENAME\\sTABLE\\s.*?`{0,1}(.*?)`{0,1}\\.{0,1}`{0,1}([^`\\.]+?)`{0,1}\\s{1,}TO\\s.*?")
+	expDropTable     = regexp.MustCompile("(?i)^DROP\\sTABLE(\\sIF\\sEXISTS){0,1}\\s`{0,1}(.*?)`{0,1}\\.{0,1}`{0,1}([^`\\.]+?)`{0,1}(?:$|\\s)")
+	expTruncateTable = regexp.MustCompile("(?i)^TRUNCATE\\s+(?:TABLE\\s+)?(?:`?([^`\\s]+)`?\\.`?)?([^`\\s]+)`?")
 )
 
 func (c *Canal) startSyncer() (*replication.BinlogStreamer, error) {
@@ -126,7 +127,7 @@ func (c *Canal) runSyncBinlog() error {
 				db    []byte
 				table []byte
 			)
-			regexps := []regexp.Regexp{*expCreateTable, *expAlterTable, *expRenameTable, *expDropTable}
+			regexps := []regexp.Regexp{*expCreateTable, *expAlterTable, *expRenameTable, *expDropTable, *expTruncateTable}
 			for _, reg := range regexps {
 				mb = reg.FindSubmatch(e.Query)
 				if len(mb) != 0 {

--- a/dump/dump.go
+++ b/dump/dump.go
@@ -121,10 +121,14 @@ func (d *Dumper) Dump(w io.Writer) error {
 	args := make([]string, 0, 16)
 
 	// Common args
-	seps := strings.Split(d.Addr, ":")
-	args = append(args, fmt.Sprintf("--host=%s", seps[0]))
-	if len(seps) > 1 {
-		args = append(args, fmt.Sprintf("--port=%s", seps[1]))
+	if strings.Contains(d.Addr, "/") {
+		args = append(args, fmt.Sprintf("--socket=%s", d.Addr))
+	} else {
+		seps := strings.SplitN(d.Addr, ":", 2)
+		args = append(args, fmt.Sprintf("--host=%s", seps[0]))
+		if len(seps) > 1 {
+			args = append(args, fmt.Sprintf("--port=%s", seps[1]))
+		}
 	}
 
 	args = append(args, fmt.Sprintf("--user=%s", d.User))

--- a/dump/parser.go
+++ b/dump/parser.go
@@ -82,7 +82,7 @@ func Parse(r io.Reader, h ParseHandler, parseBinlogPos bool) error {
 				return errors.Errorf("parse values %v err", line)
 			}
 
-			if err = h.Data(db, table, values); err != nil && err != ErrSkip {
+			if err = h.Data(db, table, values); err != nil {
 				return errors.Trace(err)
 			}
 		}

--- a/dump/parser.go
+++ b/dump/parser.go
@@ -82,7 +82,7 @@ func Parse(r io.Reader, h ParseHandler, parseBinlogPos bool) error {
 				return errors.Errorf("parse values %v err", line)
 			}
 
-			if err = h.Data(db, table, values); err != nil {
+			if err = h.Data(db, table, values); err != nil && err != ErrSkip {
 				return errors.Trace(err)
 			}
 		}

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -192,9 +193,16 @@ func (b *BinlogSyncer) registerSlave() error {
 		b.c.Close()
 	}
 
-	log.Infof("register slave for master server %s:%d", b.cfg.Host, b.cfg.Port)
+	addr := ""
+	if strings.Contains(b.cfg.Host, "/") {
+		addr = b.cfg.Host
+	} else {
+		addr = fmt.Sprintf("%s:%d", b.cfg.Host, b.cfg.Port)
+	}
+
+	log.Infof("register slave for master server %s", addr)
 	var err error
-	b.c, err = client.Connect(fmt.Sprintf("%s:%d", b.cfg.Host, b.cfg.Port), b.cfg.User, b.cfg.Password, "", func(c *client.Conn) {
+	b.c, err = client.Connect(addr, b.cfg.User, b.cfg.Password, "", func(c *client.Conn) {
 		c.TLSConfig = b.cfg.TLSConfig
 	})
 	if err != nil {


### PR DESCRIPTION
Hello.
While working on a script that does replication from mysql to cockroachdb I fixed and improved few things. Below is the list:

1. Fixed parsing of empty binary values in mysqldump output. That values look like (_binary '')
2. Errors occurred during the dump parsing were ignored
3. Error returned from OnPosChanged handler was silently ignored. My OnRow handler stores rows in memory. OnPosSynced handler atomically writes stored rows and position to cockroachdb. There was no way to handle error in such scenario
4. Added SyncedTimestamp method to canal. It's very useful for calculating replication delay. Especially in the cases when some tables ignored in the config.
5. Made it possible to connect to mysql over unix socket 
6. TRUNCATE TABLE queries are passed to OnDDL handler