### PR TITLE
Don't seed global RNG

### DIFF
--- a/canal/config.go
+++ b/canal/config.go
@@ -63,7 +63,7 @@ type Config struct {
 	Dump DumpConfig `toml:"dump"`
 
 	UseDecimal bool `toml:"use_decimal"`
-	ParseTime bool  `toml:"parse_time"`
+	ParseTime  bool `toml:"parse_time"`
 
 	// SemiSyncEnabled enables semi-sync or not.
 	SemiSyncEnabled bool `toml:"semi_sync_enabled"`
@@ -97,8 +97,7 @@ func NewDefaultConfig() *Config {
 	c.Password = ""
 
 	c.Charset = mysql.DEFAULT_CHARSET
-	rand.Seed(time.Now().Unix())
-	c.ServerID = uint32(rand.Intn(1000)) + 1001
+	c.ServerID = uint32(rand.New(rand.NewSource(time.Now().Unix())).Intn(1000)) + 1001
 
 	c.Flavor = "mysql"
 


### PR DESCRIPTION
This line caused a tricky intermittent test failure for us by creating frequent collisions of random numbers. Plus, it is just a good practice in general to avoid seeding the global RNG in a library function.

Example:
```
func TestA(t *testing.T) {
  // init canal (seeds rng)
  // some test code that doesn't call rand
}

func TestB(t *testing.T) {
  id1 := rand.Intn()
  // init canal (seeds rng to original seed if <1s has elapsed)
  id2 := rand.Intn()
  // id1 == id2
  // run an update id1 -> id2 in db, canal does not receive an update event, test fails
}
```