### PR TITLE
ignore handling optional field meta

### DIFF
--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -81,11 +81,14 @@ func (e *TableMapEvent) Decode(data []byte) error {
 
 	pos += n
 
-	if len(data[pos:]) != bitmapByteSize(int(e.ColumnCount)) {
+	nullBitmapSize := bitmapByteSize(int(e.ColumnCount))
+	if len(data[pos:]) < nullBitmapSize {
 		return io.EOF
 	}
 
-	e.NullBitmap = data[pos:]
+	e.NullBitmap = data[pos : pos+nullBitmapSize]
+
+	// TODO: handle optional field meta
 
 	return nil
 }


### PR DESCRIPTION
The TableMap event contains optional field data, but the doc https://dev.mysql.com/doc/internals/en/table-map-event.html doesn't show it, so I just ignore handing it. 