### PR TITLE
Add MaxReconnectAttempts to canal config

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -400,16 +400,17 @@ func (c *Canal) checkBinlogRowFormat() error {
 
 func (c *Canal) prepareSyncer() error {
 	cfg := replication.BinlogSyncerConfig{
-		ServerID:        c.cfg.ServerID,
-		Flavor:          c.cfg.Flavor,
-		User:            c.cfg.User,
-		Password:        c.cfg.Password,
-		Charset:         c.cfg.Charset,
-		HeartbeatPeriod: c.cfg.HeartbeatPeriod,
-		ReadTimeout:     c.cfg.ReadTimeout,
-		UseDecimal:      c.cfg.UseDecimal,
-		ParseTime:       c.cfg.ParseTime,
-		SemiSyncEnabled: c.cfg.SemiSyncEnabled,
+		ServerID:             c.cfg.ServerID,
+		Flavor:               c.cfg.Flavor,
+		User:                 c.cfg.User,
+		Password:             c.cfg.Password,
+		Charset:              c.cfg.Charset,
+		HeartbeatPeriod:      c.cfg.HeartbeatPeriod,
+		ReadTimeout:          c.cfg.ReadTimeout,
+		UseDecimal:           c.cfg.UseDecimal,
+		ParseTime:            c.cfg.ParseTime,
+		SemiSyncEnabled:      c.cfg.SemiSyncEnabled,
+		MaxReconnectAttempts: c.cfg.MaxReconnectAttempts,
 	}
 
 	if strings.Contains(c.cfg.Addr, "/") {

--- a/canal/config.go
+++ b/canal/config.go
@@ -70,6 +70,10 @@ type Config struct {
 
 	// SemiSyncEnabled enables semi-sync or not.
 	SemiSyncEnabled bool `toml:"semi_sync_enabled"`
+
+	// Set to change the maximum number of attempts to re-establish a broken
+	// connection
+	MaxReconnectAttempts int `toml:"max_reconnect_attempts"`
 }
 
 func NewConfigWithFile(name string) (*Config, error) {


### PR DESCRIPTION
Adds `MaxReconnectAttempts` to canal config.


##### Example output

```
[2019/01/22 10:06:53] [info] binlogsyncer.go:682 receive EOF packet, retry ReadPacket
[2019/01/22 10:06:53] [error] binlogsyncer.go:623 connection was bad
[2019/01/22 10:06:54] [info] binlogsyncer.go:565 begin to re-sync from (mysql-bin.000029, 154)
[2019/01/22 10:06:54] [info] binlogsyncer.go:195 register slave for master server 127.0.0.1:3306
[2019/01/22 10:06:54] [error] binlogsyncer.go:642 retry sync err: connection was bad, exceeded max retries (1)
[2019/01/22 10:06:54] [error] binlogstreamer.go:77 close sync with err: connection was bad
[2019/01/22 10:06:54] [error] canal.go:216 canal start sync binlog err: connection was bad
```