### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -368,7 +368,7 @@ func (c *Canal) ClearTableCache(db []byte, table []byte) {
 	c.tableLock.Unlock()
 }
 
-// Check MySQL binlog row image, must be in FULL, MINIMAL, NOBLOB
+// CheckBinlogRowImage checks MySQL binlog row image, must be in FULL, MINIMAL, NOBLOB
 func (c *Canal) CheckBinlogRowImage(image string) error {
 	// need to check MySQL binlog row image? full, minimal or noblob?
 	// now only log

--- a/client/conn.go
+++ b/client/conn.go
@@ -112,13 +112,13 @@ func (c *Conn) Ping() error {
 	return nil
 }
 
-// use default SSL
+// UseSSL: use default SSL
 // pass to options when connect
 func (c *Conn) UseSSL(insecureSkipVerify bool) {
 	c.tlsConfig = &tls.Config{InsecureSkipVerify: insecureSkipVerify}
 }
 
-// use user-specified TLS config
+// SetTLSConfig: use user-specified TLS config
 // pass to options when connect
 func (c *Conn) SetTLSConfig(config *tls.Config) {
 	c.tlsConfig = config

--- a/client/tls.go
+++ b/client/tls.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 )
 
-// generate TLS config for client side
+// NewClientTLSConfig: generate TLS config for client side
 // if insecureSkipVerify is set to true, serverName will not be validated
 func NewClientTLSConfig(caPem, certPem, keyPem []byte, insecureSkipVerify bool, serverName string) *tls.Config {
 	pool := x509.NewCertPool()

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -18,7 +18,7 @@ import (
 type driver struct {
 }
 
-// DSN user:password@addr[?db]
+// Open: DSN user:password@addr[?db]
 func (d driver) Open(dsn string) (sqldriver.Conn, error) {
 	lastIndex := strings.LastIndex(dsn, "@")
 	seps := []string{dsn[:lastIndex], dsn[lastIndex+1:]}

--- a/dump/dump.go
+++ b/dump/dump.go
@@ -82,7 +82,7 @@ func (d *Dumper) SetErrOut(o io.Writer) {
 	d.ErrOut = o
 }
 
-// In some cloud MySQL, we have no privilege to use `--master-data`.
+// SkipMasterData: In some cloud MySQL, we have no privilege to use `--master-data`.
 func (d *Dumper) SkipMasterData(v bool) {
 	d.masterDataSkipped = v
 }
@@ -209,7 +209,7 @@ func (d *Dumper) Dump(w io.Writer) error {
 	return cmd.Run()
 }
 
-// Dump MySQL and parse immediately
+// DumpAndParse: Dump MySQL and parse immediately
 func (d *Dumper) DumpAndParse(h ParseHandler) error {
 	r, w := io.Pipe()
 

--- a/failover/server.go
+++ b/failover/server.go
@@ -142,7 +142,7 @@ func (s *Server) UnlockTables() error {
 	return err
 }
 
-// Get current binlog filename and position read from master
+// FetchSlaveReadPos gets current binlog filename and position read from master
 func (s *Server) FetchSlaveReadPos() (Position, error) {
 	r, err := s.SlaveStatus()
 	if err != nil {
@@ -155,7 +155,7 @@ func (s *Server) FetchSlaveReadPos() (Position, error) {
 	return Position{Name: fname, Pos: uint32(pos)}, nil
 }
 
-// Get current executed binlog filename and position from master
+// FetchSlaveExecutePos gets current executed binlog filename and position from master
 func (s *Server) FetchSlaveExecutePos() (Position, error) {
 	r, err := s.SlaveStatus()
 	if err != nil {

--- a/mysql/error.go
+++ b/mysql/error.go
@@ -23,7 +23,7 @@ func (e *MyError) Error() string {
 	return fmt.Sprintf("ERROR %d (%s): %s", e.Code, e.State, e.Message)
 }
 
-//default mysql error, must adapt errname message format
+// NewDefaultError: default mysql error, must adapt errname message format
 func NewDefaultError(errCode uint16, args ...interface{}) *MyError {
 	e := new(MyError)
 	e.Code = errCode

--- a/mysql/mysql_gtid.go
+++ b/mysql/mysql_gtid.go
@@ -108,7 +108,7 @@ func (s IntervalSlice) Normalize() IntervalSlice {
 	return n
 }
 
-// Return true if sub in s
+// Contain returns true if sub in s
 func (s IntervalSlice) Contain(sub IntervalSlice) bool {
 	j := 0
 	for i := 0; i < len(sub); i++ {

--- a/mysql/util.go
+++ b/mysql/util.go
@@ -50,7 +50,7 @@ func CalcPassword(scramble, password []byte) []byte {
 	return scramble
 }
 
-// Hash password using MySQL 8+ method (SHA256)
+// CalcCachingSha2Password: Hash password using MySQL 8+ method (SHA256)
 func CalcCachingSha2Password(scramble []byte, password string) []byte {
 	if len(password) == 0 {
 		return nil
@@ -89,7 +89,7 @@ func EncryptPassword(password string, seed []byte, pub *rsa.PublicKey) ([]byte, 
 	return rsa.EncryptOAEP(sha1v, rand.Reader, pub, plain, nil)
 }
 
-// encodes a uint64 value and appends it to the given bytes slice
+// AppendLengthEncodedInteger: encodes a uint64 value and appends it to the given bytes slice
 func AppendLengthEncodedInteger(b []byte, n uint64) []byte {
 	switch {
 	case n <= 250:
@@ -122,7 +122,7 @@ func RandomBuf(size int) ([]byte, error) {
 	return buf, nil
 }
 
-// little endian
+// FixedLengthInt: little endian
 func FixedLengthInt(buf []byte) uint64 {
 	var num uint64 = 0
 	for i, b := range buf {
@@ -131,7 +131,7 @@ func FixedLengthInt(buf []byte) uint64 {
 	return num
 }
 
-// big endian
+// BFixedLengthInt: big endian
 func BFixedLengthInt(buf []byte) uint64 {
 	var num uint64 = 0
 	for i, b := range buf {
@@ -188,7 +188,7 @@ func PutLengthEncodedInt(n uint64) []byte {
 	return nil
 }
 
-// returns the string read as a bytes slice, whether the value is NULL,
+// LengthEncodedString returns the string read as a bytes slice, whether the value is NULL,
 // the number of bytes read and an error, in case the string is longer than
 // the input slice
 func LengthEncodedString(b []byte) ([]byte, bool, int, error) {
@@ -345,7 +345,7 @@ var (
 	EncodeMap [256]byte
 )
 
-// only support utf-8
+// Escape: only support utf-8
 func Escape(sql string) string {
 	dest := make([]byte, 0, 2*len(sql))
 

--- a/packet/conn.go
+++ b/packet/conn.go
@@ -83,7 +83,7 @@ func (c *Conn) ReadPacketTo(w io.Writer) error {
 	return nil
 }
 
-// data already has 4 bytes header
+// WritePacket: data already has 4 bytes header
 // will modify data inplace
 func (c *Conn) WritePacket(data []byte) error {
 	length := len(data) - 4
@@ -121,7 +121,7 @@ func (c *Conn) WritePacket(data []byte) error {
 	}
 }
 
-//  Client clear text authentication packet
+// WriteClearAuthPacket: Client clear text authentication packet
 // http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::AuthSwitchResponse
 func (c *Conn) WriteClearAuthPacket(password string) error {
 	// Calculate the packet length and add a tailing 0
@@ -135,7 +135,7 @@ func (c *Conn) WriteClearAuthPacket(password string) error {
 	return c.WritePacket(data)
 }
 
-//  Caching sha2 authentication. Public key request and send encrypted password
+// WritePublicKeyAuthPacket: Caching sha2 authentication. Public key request and send encrypted password
 // http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::AuthSwitchResponse
 func (c *Conn) WritePublicKeyAuthPacket(password string, cipher []byte) error {
 	// request public key

--- a/replication/backup.go
+++ b/replication/backup.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/siddontang/go-mysql/mysql"
 )
 
-// Like mysqlbinlog remote raw backup
+// StartBackup: Like mysqlbinlog remote raw backup
 // Backup remote binlog from position (filename, offset) and write in backupDir
 func (b *BinlogSyncer) StartBackup(backupDir string, p Position, timeout time.Duration) error {
 	if timeout == 0 {

--- a/replication/binlogstreamer.go
+++ b/replication/binlogstreamer.go
@@ -36,7 +36,7 @@ func (s *BinlogStreamer) GetEvent(ctx context.Context) (*BinlogEvent, error) {
 	}
 }
 
-// Get the binlog event with starttime, if current binlog event timestamp smaller than specify starttime
+// GetEventWithStartTime gets the binlog event with starttime, if current binlog event timestamp smaller than specify starttime
 // return nil event
 func (s *BinlogStreamer) GetEventWithStartTime(ctx context.Context, startTime time.Time) (*BinlogEvent, error) {
 	if s.err != nil {

--- a/replication/parser.go
+++ b/replication/parser.go
@@ -292,7 +292,7 @@ func (p *BinlogParser) parseEvent(h *EventHeader, data []byte, rawData []byte) (
 	return e, nil
 }
 
-// Given the bytes for a a binary log event: return the decoded event.
+// Parse: Given the bytes for a a binary log event: return the decoded event.
 // With the exception of the FORMAT_DESCRIPTION_EVENT event type
 // there must have previously been passed a FORMAT_DESCRIPTION_EVENT
 // into the parser for this to work properly on any given event.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -368,7 +368,7 @@ func (ta *Table) fetchPrimaryKeyColumns() error {
 	return nil
 }
 
-// Get primary keys in one row for a table, a table may use multi fields as the PK
+// GetPKValues gets primary keys in one row for a table, a table may use multi fields as the PK
 func (ta *Table) GetPKValues(row []interface{}) ([]interface{}, error) {
 	indexes := ta.PKColumns
 	if len(indexes) == 0 {
@@ -387,7 +387,7 @@ func (ta *Table) GetPKValues(row []interface{}) ([]interface{}, error) {
 	return values, nil
 }
 
-// Get term column's value
+// GetColumnValue gets term column's value
 func (ta *Table) GetColumnValue(column string, row []interface{}) (interface{}, error) {
 	index := ta.FindColumn(column)
 	if index == -1 {

--- a/server/conn.go
+++ b/server/conn.go
@@ -37,7 +37,7 @@ type Conn struct {
 
 var baseConnID uint32 = 10000
 
-// create connection with default server settings
+// NewConn: create connection with default server settings
 func NewConn(conn net.Conn, user string, password string, h Handler) (*Conn, error) {
 	p := NewInMemoryProvider()
 	p.AddUser(user, password)
@@ -61,7 +61,7 @@ func NewConn(conn net.Conn, user string, password string, h Handler) (*Conn, err
 	return c, nil
 }
 
-// create connection with customized server settings
+// NewCustomizedConn: create connection with customized server settings
 func NewCustomizedConn(conn net.Conn, serverConf *Server, p CredentialProvider, h Handler) (*Conn, error) {
 	salt, _ := RandomBuf(20)
 	c := &Conn{

--- a/server/server_conf.go
+++ b/server/server_conf.go
@@ -36,7 +36,7 @@ type Server struct {
 	cacheShaPassword  *sync.Map // 'user@host' -> SHA256(SHA256(PASSWORD))
 }
 
-// New mysql server with default settings.
+// NewDefaultServer: New mysql server with default settings.
 //
 // NOTES:
 // TLS support will be enabled by default with auto-generated CA and server certificates (however, you can still use
@@ -60,7 +60,7 @@ func NewDefaultServer() *Server {
 	}
 }
 
-// New mysql server with customized settings.
+// NewServer: New mysql server with customized settings.
 //
 // NOTES:
 // You can control the authentication methods and TLS settings here.

--- a/server/ssl.go
+++ b/server/ssl.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-// generate TLS config for server side
+// NewServerTLSConfig: generate TLS config for server side
 // controlling the security level by authType
 func NewServerTLSConfig(caPem, certPem, keyPem []byte, authType tls.ClientAuthType) *tls.Config {
 	pool := x509.NewCertPool()


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, *but this is automated so feel free to close it and just say **`opt out`** to opt out of future CodeLingo outreach PRs.*