### PR TITLE
add compatibility to json decode for generated column

### DIFF
--- a/replication/json_binary.go
+++ b/replication/json_binary.go
@@ -76,7 +76,10 @@ func (e *RowsEvent) decodeJsonBinary(data []byte) ([]byte, error) {
 	if len(data) == 0 {
 		return []byte{}, nil
 	}
-	d := jsonBinaryDecoder{useDecimal: e.useDecimal}
+	d := jsonBinaryDecoder{
+		useDecimal:      e.useDecimal,
+		ignoreDecodeErr: e.ignoreJSONDecodeErr,
+	}
 
 	if d.isDataShort(data, 1) {
 		return nil, d.err
@@ -91,8 +94,9 @@ func (e *RowsEvent) decodeJsonBinary(data []byte) ([]byte, error) {
 }
 
 type jsonBinaryDecoder struct {
-	useDecimal bool
-	err        error
+	useDecimal      bool
+	ignoreDecodeErr bool
+	err             error
 }
 
 func (d *jsonBinaryDecoder) decodeValue(tp byte, data []byte) interface{} {
@@ -146,6 +150,13 @@ func (d *jsonBinaryDecoder) decodeObjectOrArray(data []byte, isSmall bool, isObj
 	size := d.decodeCount(data[offsetSize:], isSmall)
 
 	if d.isDataShort(data, int(size)) {
+		// Before MySQL 5.7.22, json type generated column may have invalid value,
+		// bug ref: https://bugs.mysql.com/bug.php?id=88791
+		// As generated column value is not used in replication, we can just ignore
+		// this error and return a dummy value for this column.
+		if d.ignoreDecodeErr {
+			d.err = nil
+		}
 		return nil
 	}
 

--- a/replication/parser.go
+++ b/replication/parser.go
@@ -32,8 +32,9 @@ type BinlogParser struct {
 	// used to start/stop processing
 	stopProcessing uint32
 
-	useDecimal     bool
-	verifyChecksum bool
+	useDecimal          bool
+	ignoreJSONDecodeErr bool
+	verifyChecksum      bool
 }
 
 func NewBinlogParser() *BinlogParser {
@@ -189,6 +190,10 @@ func (p *BinlogParser) SetTimestampStringLocation(timestampStringLocation *time.
 
 func (p *BinlogParser) SetUseDecimal(useDecimal bool) {
 	p.useDecimal = useDecimal
+}
+
+func (p *BinlogParser) SetIgnoreJSONDecodeError(ignoreJSONDecodeErr bool) {
+	p.ignoreJSONDecodeErr = ignoreJSONDecodeErr
 }
 
 func (p *BinlogParser) SetVerifyChecksum(verify bool) {
@@ -355,6 +360,7 @@ func (p *BinlogParser) newRowsEvent(h *EventHeader) *RowsEvent {
 	e.parseTime = p.parseTime
 	e.timestampStringLocation = p.timestampStringLocation
 	e.useDecimal = p.useDecimal
+	e.ignoreJSONDecodeErr = p.ignoreJSONDecodeErr
 
 	switch h.EventType {
 	case WRITE_ROWS_EVENTv0:

--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -233,6 +233,7 @@ type RowsEvent struct {
 	parseTime               bool
 	timestampStringLocation *time.Location
 	useDecimal              bool
+	ignoreJSONDecodeErr     bool
 }
 
 func (e *RowsEvent) Decode(data []byte) error {


### PR DESCRIPTION
### What problem does this PR solve? 
fix bug found in https://github.com/pingcap/tidb/issues/8761 , which is similar to a MySQL bug: https://bugs.mysql.com/bug.php?id=88791

### What is changed and how it works?
add a switch to control whether we will ignore this error during jsonBinaryDecoder decode

### Side effects
When we decode a json binary and meet a `isDataShort` error, we don't have enough context to distinguish whether it is caused by this MySQL bug, so we may miss an unexpected error and return an invalid decode result.
However before we decode a json binary, the length of this value is known in advance from code [replication/row_event.go#L517](https://github.com/siddontang/go-mysql/blob/master/replication/row_event.go#L517) and we can believe the `isDataShort` error is definitely a MySQL bug or binlog data inconsistent.

### Tests 
 - Unit test