### PR TITLE
*: support to request Annotate_rows_log_event from MariaDB master

### DIFF
--- a/replication/const.go
+++ b/replication/const.go
@@ -30,6 +30,13 @@ const (
 	BINLOG_DUMP_NON_BLOCK   uint16 = 0x01
 	BINLOG_THROUGH_POSITION uint16 = 0x02
 	BINLOG_THROUGH_GTID     uint16 = 0x04
+
+	// binlog dump flags for MariaDB.
+	// see https://mariadb.com/kb/en/library/com_binlog_dump/.
+	// in MySQL Internals Manual (https://dev.mysql.com/doc/internals/en/com-binlog-dump-gtid.html),
+	// BINLOG_THROUGH_POSITION also defined as 0x02, but it can not be found in the source code of MySQL 5.6/5.7.
+	// and in the source code of MariaDB 10.1, `#define BINLOG_SEND_ANNOTATE_ROWS_EVENT   2` exists.
+	BINLOG_SEND_ANNOTATE_ROWS_EVENT uint16 = 0x02
 )
 
 const (


### PR DESCRIPTION
for MariaDB:

1. if the [--binlog-annotate-row-events](https://mariadb.com/kb/en/library/annotate_rows_log_event/#master-option-binlog-annotate-row-events) option enabled in the master, it will  write Annotate_rows events to the binary log
2. if the [--replicate-annotate-row-events](https://mariadb.com/kb/en/library/annotate_rows_log_event/#slave-option-replicate-annotate-row-events) option enabled in the slave, it will request the master to send Annotate_rows events and write them to its owner binary log

before this PR, go-mysql will receive a dummy QueryEvent (ref [MariaDB source code](https://github.com/MariaDB/server/blob/bf71d263621c90cbddc7bde9bf071dae503f333f/sql/sql_repl.cc#L1809)) rather than a MariadbAnnotateRowsEvent, like
```
 === QueryEvent ===
Date: 2019-03-08 16:09:05
Log position: 1403
Event size: 48
Slave proxy ID: 0
Execution time: 0
Error code: 0
Schema:
Query: # Dummy event r
```

in this PR, a dump commnad flag (`BINLOG_SEND_ANNOTATE_ROWS_EVENT`) was added, then go-mysql can receive MariadbAnnotateRowsEvent, like
```
=== MariadbAnnotateRowsEvent ===
Date: 2019-03-08 16:09:05
Log position: 1403
Event size: 48
Query: INSERT INTO db.tbl VALUES (5)
```