### PR TITLE
Track canal replication delay with a gauge metric

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -46,6 +46,8 @@ type Canal struct {
 	includeTableRegex []*regexp.Regexp
 	excludeTableRegex []*regexp.Regexp
 
+	delay uint32
+
 	ctx    context.Context
 	cancel context.CancelFunc
 }
@@ -164,6 +166,10 @@ func (c *Canal) prepareDumper() error {
 	}
 
 	return nil
+}
+
+func (c *Canal) GetDelay() uint32 {
+	return c.delay
 }
 
 // Run will first try to dump all data from MySQL master `mysqldump`,

--- a/canal/canal.go
+++ b/canal/canal.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -46,7 +47,7 @@ type Canal struct {
 	includeTableRegex []*regexp.Regexp
 	excludeTableRegex []*regexp.Regexp
 
-	delay uint32
+	delay *uint32
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -70,6 +71,8 @@ func NewCanal(cfg *Config) (*Canal, error) {
 		c.errorTablesGetTime = make(map[string]time.Time)
 	}
 	c.master = &masterInfo{}
+	
+	c.delay = new(0)
 
 	var err error
 
@@ -169,7 +172,7 @@ func (c *Canal) prepareDumper() error {
 }
 
 func (c *Canal) GetDelay() uint32 {
-	return c.delay
+	return atomic.LoadUint32(c.delay)
 }
 
 // Run will first try to dump all data from MySQL master `mysqldump`,

--- a/canal/canal.go
+++ b/canal/canal.go
@@ -72,7 +72,7 @@ func NewCanal(cfg *Config) (*Canal, error) {
 	}
 	c.master = &masterInfo{}
 	
-	c.delay = new(0)
+	c.delay = new(uint32)
 
 	var err error
 

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -55,6 +55,10 @@ func (c *Canal) runSyncBinlog() error {
 		if err != nil {
 			return errors.Trace(err)
 		}
+
+		// Update the delay between the Canal and the Master before the handler hooks are called
+		c.updateReplicationDelay(ev)
+
 		savePos = false
 		force = false
 		pos := c.master.Position()
@@ -173,6 +177,10 @@ func (c *Canal) runSyncBinlog() error {
 	}
 
 	return nil
+}
+
+func (c *Canal) updateReplicationDelay(ev *replication.BinlogEvent) {
+	c.delay = uint32(time.Now().Unix()) - ev.Header.Timestamp
 }
 
 func (c *Canal) handleRowsEvent(e *replication.BinlogEvent) error {

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -3,6 +3,7 @@ package canal
 import (
 	"fmt"
 	"regexp"
+	"sync/atomic"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -180,7 +181,7 @@ func (c *Canal) runSyncBinlog() error {
 }
 
 func (c *Canal) updateReplicationDelay(ev *replication.BinlogEvent) {
-	c.delay = uint32(time.Now().Unix()) - ev.Header.Timestamp
+	atomic.AddUint32(c.delay, uint32(time.Now().Unix()) - ev.Header.Timestamp)
 }
 
 func (c *Canal) handleRowsEvent(e *replication.BinlogEvent) error {


### PR DESCRIPTION
Need a way to track replication delay without duplicating code over each hook