### PR TITLE
Modify the RegisterSlaveCommand to ensure it is safe and suitable..

### DIFF
--- a/replication/const.go
+++ b/replication/const.go
@@ -39,6 +39,10 @@ const (
 	BINLOG_ROW_IMAGE_NOBLOB  = "NOBLOB"
 )
 
+const (
+	BINLOG_MARIADB_FL_GROUP_COMMIT_ID uint8 = 0x02
+)
+
 type EventType byte
 
 const (

--- a/replication/event.go
+++ b/replication/event.go
@@ -440,20 +440,29 @@ func (e *MariadbBinlogCheckPointEvent) Dump(w io.Writer) {
 }
 
 type MariadbGTIDEvent struct {
-	GTID MariadbGTID
+	GTID     MariadbGTID
+	CommitID uint64
 }
 
 func (e *MariadbGTIDEvent) Decode(data []byte) error {
+	pos := 0
 	e.GTID.SequenceNumber = binary.LittleEndian.Uint64(data)
-	e.GTID.DomainID = binary.LittleEndian.Uint32(data[8:])
+	pos += 8
+	e.GTID.DomainID = binary.LittleEndian.Uint32(data[pos:])
+	pos += 4
+	flag := uint8(data[pos])
+	pos += 1
 
-	// we don't care commit id now, maybe later
+	if (flag & BINLOG_MARIADB_FL_GROUP_COMMIT_ID) > 0 {
+		e.CommitID = binary.LittleEndian.Uint64(data[pos:])
+	}
 
 	return nil
 }
 
 func (e *MariadbGTIDEvent) Dump(w io.Writer) {
 	fmt.Fprintf(w, "GTID: %v\n", e.GTID)
+	fmt.Fprintf(w, "COMMITID: %v\n", e.CommitID)
 	fmt.Fprintln(w)
 }
 


### PR DESCRIPTION
[Slave hostname, slave user, slave password and slave port are usually not set.](https://mariadb.com/kb/en/library/com_register_slave/)

1. We better not to submit a Cleartext password.
2. The slave port will be shown in the master as the following text. The binlog_syncer is not listening on any ports, so setting it to 0 is suitable.

```
MariaDB [(none)]> show slave hosts;
+-----------+----------------------------+------+-----------+
| Server_id | Host                       | Port | Master_id |
+-----------+----------------------------+------+-----------+
|       100 | huzilin                    | 3308 |   1024428 |
+-----------+----------------------------+------+-----------+

MariaDB [(none)]> show slave hosts;
+-----------+----------------------------+------+-----------+
| Server_id | Host                       | Port | Master_id |
+-----------+----------------------------+------+-----------+
|       100 | huzilin                    |    0 |   1024428 |
+-----------+----------------------------+------+-----------+
```