### PR TITLE
Replication delay should be updated with atomic.StoreUint32

### DIFF
--- a/canal/sync.go
+++ b/canal/sync.go
@@ -213,7 +213,12 @@ func (c *Canal) updateTable(db, table string) (err error) {
 	return
 }
 func (c *Canal) updateReplicationDelay(ev *replication.BinlogEvent) {
-	atomic.AddUint32(c.delay, uint32(time.Now().Unix())-ev.Header.Timestamp)
+	var newDelay uint32
+	now := uint32(time.Now().Unix())
+	if now >= ev.Header.Timestamp {
+		newDelay = now - ev.Header.Timestamp
+	}
+	atomic.StoreUint32(c.delay, newDelay)
 }
 
 func (c *Canal) handleRowsEvent(e *replication.BinlogEvent) error {


### PR DESCRIPTION
For some reason `delay` field introduced in #380 was being updated with `atomic.AddUint32`, although it's a gauge metric.