### PR TITLE
fix(canal): fix "Index of range error" for unsigned columns

### DIFF
--- a/canal/rows.go
+++ b/canal/rows.go
@@ -2,6 +2,7 @@ package canal
 
 import (
 	"fmt"
+
 	"github.com/siddontang/go-mysql/replication"
 	"github.com/siddontang/go-mysql/schema"
 )
@@ -58,15 +59,14 @@ func (r *RowsEvent) handleUnsigned() {
 			case int16:
 				r.Rows[i][index] = uint16(t)
 			case int32:
-				if r.Table.Columns[i].Type == schema.TYPE_MEDIUM_INT {
+				if r.Table.Columns[index].Type == schema.TYPE_MEDIUM_INT {
 					// problem with mediumint is that it's a 3-byte type. There is no compatible golang type to match that.
 					// So to convert from negative to positive we'd need to convert the value manually
-					if i >= 0 {
+					if t >= 0 {
 						r.Rows[i][index] = uint32(t)
 					} else {
 						r.Rows[i][index] = uint32(maxMediumintUnsigned + t + 1)
 					}
-					return
 				} else {
 					r.Rows[i][index] = uint32(t)
 				}

--- a/canal/rows.go
+++ b/canal/rows.go
@@ -52,28 +52,24 @@ func (r *RowsEvent) handleUnsigned() {
 	}
 
 	for i := 0; i < len(r.Rows); i++ {
-		for _, index := range r.Table.UnsignedColumns {
-			switch t := r.Rows[i][index].(type) {
+		for _, columnIdx := range r.Table.UnsignedColumns {
+			switch value := r.Rows[i][columnIdx].(type) {
 			case int8:
-				r.Rows[i][index] = uint8(t)
+				r.Rows[i][columnIdx] = uint8(value)
 			case int16:
-				r.Rows[i][index] = uint16(t)
+				r.Rows[i][columnIdx] = uint16(value)
 			case int32:
-				if r.Table.Columns[index].Type == schema.TYPE_MEDIUM_INT {
-					// problem with mediumint is that it's a 3-byte type. There is no compatible golang type to match that.
-					// So to convert from negative to positive we'd need to convert the value manually
-					if t >= 0 {
-						r.Rows[i][index] = uint32(t)
-					} else {
-						r.Rows[i][index] = uint32(maxMediumintUnsigned + t + 1)
-					}
+				// problem with mediumint is that it's a 3-byte type. There is no compatible golang type to match that.
+				// So to convert from negative to positive we'd need to convert the value manually
+				if value < 0 && r.Table.Columns[columnIdx].Type == schema.TYPE_MEDIUM_INT {
+					r.Rows[i][columnIdx] = uint32(maxMediumintUnsigned + value + 1)
 				} else {
-					r.Rows[i][index] = uint32(t)
+					r.Rows[i][columnIdx] = uint32(value)
 				}
 			case int64:
-				r.Rows[i][index] = uint64(t)
+				r.Rows[i][columnIdx] = uint64(value)
 			case int:
-				r.Rows[i][index] = uint(t)
+				r.Rows[i][columnIdx] = uint(value)
 			default:
 				// nothing to do
 			}

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -51,7 +51,11 @@ func (c *Canal) runSyncBinlog() error {
 
 		// Update the delay between the Canal and the Master before the handler hooks are called
 		c.updateReplicationDelay(ev)
-
+		// if log pos equal zero ,it is a fake rotate event,ignore it.
+		// see https://github.com/mysql/mysql-server/blob/8cc757da3d87bf4a1f07dcfb2d3c96fed3806870/sql/rpl_binlog_sender.cc#L899
+		if ev.Header.LogPos == 0 {
+			continue
+		}
 		savePos = false
 		force = false
 		pos := c.master.Position()

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -50,11 +50,7 @@ func (c *Canal) runSyncBinlog() error {
 
 		// Update the delay between the Canal and the Master before the handler hooks are called
 		c.updateReplicationDelay(ev)
-		// if log pos equal zero ,it is a fake rotate event,ignore it.
-		// see https://github.com/mysql/mysql-server/blob/8cc757da3d87bf4a1f07dcfb2d3c96fed3806870/sql/rpl_binlog_sender.cc#L899
-		if ev.Header.LogPos == 0 {
-			continue
-		}
+
 		savePos = false
 		force = false
 		pos := c.master.Position()


### PR DESCRIPTION
It seems that several errors were introduced in the #399 

https://github.com/siddontang/go-mysql/blob/046188b858f9a4b47cdedb11068eb868463fcb75/canal/rows.go#L53-L72

- `i` in L61 is an index of the row, not an index of the column. I guess `index` should be used.
- `i` in L64 is always >= 0 since it's an index of the row. Probably it should be `t` here.
- Weird `return` in L69. I don't know why we must stop processing other rows after we've found a first mediumint column.
- Duplicated code in L65 and L71 could be avoided by combining conditions in L61 and L64.

Also I suggest to rename `index` to `columnIdx`, `t` to `value`.

Fixes #404 