### PR TITLE
replication: support datetime less than unix timestamp zero

### DIFF
--- a/replication/row_event_test.go
+++ b/replication/row_event_test.go
@@ -744,6 +744,9 @@ func (_ *testDecodeSuite) TestDecodeDatetime2(c *C) {
 		{[]byte("\x80\x00\x00\x00\x00"), 0, false, "0000-00-00 00:00:00"},
 		{[]byte("\x80\x00\x02\xf1\x05"), 0, false, "0000-00-01 15:04:05"},
 		{[]byte("\x80\x03\x82\x00\x00"), 0, false, "0001-01-01 00:00:00"},
+		{[]byte("\x80\x03\x82\x00\x00\x0c"), uint16(2), false, "0001-01-01 00:00:00.12"},
+		{[]byte("\x80\x03\x82\x00\x00\x04\xd3"), uint16(4), false, "0001-01-01 00:00:00.1235"},
+		{[]byte("\x80\x03\x82\x00\x00\x01\xe2\x40"), uint16(6), false, "0001-01-01 00:00:00.123456"},
 	}
 	for _, tc := range testcases {
 		value, _, err := decodeDatetime2(tc.data, tc.dec)

--- a/replication/row_event_test.go
+++ b/replication/row_event_test.go
@@ -730,3 +730,33 @@ func (_ *testDecodeSuite) TestJsonCompatibility(c *C) {
 	c.Assert(rows.Rows[1][2], DeepEquals, []uint8("{}"))
 	c.Assert(rows.Rows[2][2], DeepEquals, []uint8("{}"))
 }
+
+func (_ *testDecodeSuite) TestDecodeDatetime2(c *C) {
+	testcases := []struct {
+		data        []byte
+		dec         uint16
+		getFracTime bool
+		expected    string
+	}{
+		{[]byte("\xfe\xf3\xff\x7e\xfb"), 0, true, "9999-12-31 23:59:59"},
+		{[]byte("\x99\x9a\xb8\xf7\xaa"), 0, true, "2016-10-28 15:30:42"},
+		{[]byte("\x99\x02\xc2\x00\x00"), 0, true, "1970-01-01 00:00:00"},
+		{[]byte("\x80\x00\x00\x00\x00"), 0, false, "0000-00-00 00:00:00"},
+		{[]byte("\x80\x00\x02\xf1\x05"), 0, false, "0000-00-01 15:04:05"},
+		{[]byte("\x80\x03\x82\x00\x00"), 0, false, "0001-01-01 00:00:00"},
+	}
+	for _, tc := range testcases {
+		value, _, err := decodeDatetime2(tc.data, tc.dec)
+		c.Assert(err, IsNil)
+		switch t := value.(type) {
+		case fracTime:
+			c.Assert(tc.getFracTime, IsTrue)
+			c.Assert(t.String(), Equals, tc.expected)
+		case string:
+			c.Assert(tc.getFracTime, IsFalse)
+			c.Assert(t, Equals, tc.expected)
+		default:
+			c.Errorf("invalid value type: %T", value)
+		}
+	}
+}

--- a/replication/time.go
+++ b/replication/time.go
@@ -39,6 +39,17 @@ func formatZeroTime(frac int, dec int) string {
 	return s[0 : len(s)-(6-dec)]
 }
 
+func formatBeforeUnixZeroTime(year, month, day, hour, minute, second, frac, dec int) string {
+	if dec == 0 {
+		return fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, minute, second)
+	}
+
+	s := fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d.%06d", year, month, day, hour, minute, second, frac)
+
+	// dec must < 6, if frac is 924000, but dec is 3, we must output 924 here.
+	return s[0 : len(s)-(6-dec)]
+}
+
 func init() {
 	fracTimeFormat = make([]string, 7)
 	fracTimeFormat[0] = "2006-01-02 15:04:05"


### PR DESCRIPTION
## What problem does this PR solve?
Golang standard library doesn't support datetime before `1970-01-01 00:00:00` very well, for example the following code snippet will get result
```
package main

import (
    "fmt"
    "time"
)

func main() {
    var (
        year   = 0
        month  = 0
        day    = 1
        hour   = 21
        minute = 30
        second = 42
    )
    t := time.Date(year, time.Month(month), day, hour, minute, second, 0, time.UTC)
    fmt.Printf("%s\n%d\n", t, t.Unix())
}
```

```
-0001-12-01 21:30:42 +0000 UTC
-62169820158
```
This will affect datetime type replication.

## What is changed and how it works?

Return the string format of a datetime directly if it is before `1970-01-01 00:00:00`

## Side effects
We may lose time zone conversion for datetime before `1970-01-01 00:00:00`. But the zero datetime (`0000-00-00 00:00:00`) still has this issue before this pr. Users should take their own risks to use these datetime values if upstream and downstream have different timezones. 

## Tests
Unit test