### PR TITLE
fix mysql connect error in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,13 @@ go:
 services:
     mysql
 
+dist:
+    xenial
+
 addons:
   apt:
     sources:
-      - mysql-5.7-trusty
+      - mysql-5.7
     packages:
       - mysql-server
       - mysql-client

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: go
 go:
   - "1.11"
 
+services:
+    mysql
+
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,9 @@ before_install:
   - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
   - sudo mysql_upgrade
 
-  # stop mysql and use row-based format binlog
+  # create ssl/rsa files for mysql ssl support
   - "sudo mysql_ssl_rsa_setup --uid=mysql"
+  # stop mysql and use row-based format binlog
   - "sudo service mysql stop || true"
   - "echo '[mysqld]'            | sudo tee /etc/mysql/conf.d/replication.cnf"
   - "echo 'server-id=1'         | sudo tee -a /etc/mysql/conf.d/replication.cnf"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
   - sudo mysql_upgrade
 
   # stop mysql and use row-based format binlog
+  - "sudo mysql_ssl_rsa_setup --uid=mysql"
   - "sudo service mysql stop || true"
   - "echo '[mysqld]'            | sudo tee /etc/mysql/conf.d/replication.cnf"
   - "echo 'server-id=1'         | sudo tee -a /etc/mysql/conf.d/replication.cnf"

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -25,11 +25,12 @@ func (c *Canal) startSyncer() (*replication.BinlogStreamer, error) {
 		log.Infof("start sync binlog at binlog file %v", pos)
 		return s, nil
 	} else {
+		gsetClone := gset.Clone()
 		s, err := c.syncer.StartSyncGTID(gset)
 		if err != nil {
 			return nil, errors.Errorf("start sync replication at GTID set %v error %v", gset, err)
 		}
-		log.Infof("start sync binlog at GTID set %v", gset)
+		log.Infof("start sync binlog at GTID set %v", gsetClone)
 		return s, nil
 	}
 }


### PR DESCRIPTION
CI on travis always meets the following error recently:
```
$ sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)
The command "sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"" failed and exited with 1 during .
```
ref: https://travis-ci.community/t/cant-connect-to-local-mysql-server-through-socket-var-run-mysqld-mysqld-sock/3414/2
- add service `mysql` to fix this error
- as `SSL/TLS` is not enabled by default, we run `sudo mysql_ssl_rsa_setup --uid=mysql` to enable it
- fix a data race in canal package