### PR TITLE
Fix unclosed conn, shutdown errors

### DIFF
--- a/replication/binlogstreamer.go
+++ b/replication/binlogstreamer.go
@@ -67,14 +67,16 @@ func (s *BinlogStreamer) DumpEvents() []*BinlogEvent {
 }
 
 func (s *BinlogStreamer) close() {
-	s.closeWithError(ErrSyncClosed)
+	s.closeWithError(nil)
 }
 
 func (s *BinlogStreamer) closeWithError(err error) {
 	if err == nil {
 		err = ErrSyncClosed
+	} else {
+		log.Errorf("close sync with err: %v", err)
 	}
-	log.Errorf("close sync with err: %v", err)
+
 	select {
 	case s.ech <- err:
 	default:


### PR DESCRIPTION
Closing a canal by calling Close() results in errors as described in #273.
Fix that by explicitly ignoring context cancellation as it's not really
an error, but an expected part of Close().

Also fix the unclosed connection described in #361 by using a
separate connection to kill the binlog streamer.