### PR TITLE
refine usage of MaxReconnectAttempts in BinlogSyncer

### DIFF
--- a/replication/replication_test.go
+++ b/replication/replication_test.go
@@ -158,8 +158,8 @@ func (t *testSyncerSuite) testSync(c *C, s *BinlogStreamer) {
 	t.testExecute(c, "DROP TABLE IF EXISTS test_json_v2")
 
 	str = `CREATE TABLE test_json_v2 (
-			id INT, 
-			c JSON, 
+			id INT,
+			c JSON,
 			PRIMARY KEY (id)
 			) ENGINE=InnoDB`
 
@@ -236,20 +236,20 @@ func (t *testSyncerSuite) testSync(c *C, s *BinlogStreamer) {
 	// Must allow zero time.
 	t.testExecute(c, `SET sql_mode=''`)
 	str = `CREATE TABLE test_parse_time (
-			a1 DATETIME, 
-			a2 DATETIME(3), 
-			a3 DATETIME(6), 
-			b1 TIMESTAMP, 
-			b2 TIMESTAMP(3) , 
+			a1 DATETIME,
+			a2 DATETIME(3),
+			a3 DATETIME(6),
+			b1 TIMESTAMP,
+			b2 TIMESTAMP(3) ,
 			b3 TIMESTAMP(6))`
 	t.testExecute(c, str)
 
 	t.testExecute(c, `INSERT INTO test_parse_time VALUES
-		("2014-09-08 17:51:04.123456", "2014-09-08 17:51:04.123456", "2014-09-08 17:51:04.123456", 
+		("2014-09-08 17:51:04.123456", "2014-09-08 17:51:04.123456", "2014-09-08 17:51:04.123456",
 		"2014-09-08 17:51:04.123456","2014-09-08 17:51:04.123456","2014-09-08 17:51:04.123456"),
 		("0000-00-00 00:00:00.000000", "0000-00-00 00:00:00.000000", "0000-00-00 00:00:00.000000",
 		"0000-00-00 00:00:00.000000", "0000-00-00 00:00:00.000000", "0000-00-00 00:00:00.000000"),
-		("2014-09-08 17:51:04.000456", "2014-09-08 17:51:04.000456", "2014-09-08 17:51:04.000456", 
+		("2014-09-08 17:51:04.000456", "2014-09-08 17:51:04.000456", "2014-09-08 17:51:04.000456",
 		"2014-09-08 17:51:04.000456","2014-09-08 17:51:04.000456","2014-09-08 17:51:04.000456")`)
 
 	t.wg.Wait()
@@ -285,14 +285,13 @@ func (t *testSyncerSuite) setupTest(c *C, flavor string) {
 	}
 
 	cfg := BinlogSyncerConfig{
-		ServerID:             100,
-		Flavor:               flavor,
-		Host:                 *testHost,
-		Port:                 port,
-		User:                 "root",
-		Password:             "",
-		UseDecimal:           true,
-		MaxReconnectAttempts: 1,
+		ServerID:   100,
+		Flavor:     flavor,
+		Host:       *testHost,
+		Port:       port,
+		User:       "root",
+		Password:   "",
+		UseDecimal: true,
 	}
 
 	t.b = NewBinlogSyncer(cfg)

--- a/replication/replication_test.go
+++ b/replication/replication_test.go
@@ -285,13 +285,14 @@ func (t *testSyncerSuite) setupTest(c *C, flavor string) {
 	}
 
 	cfg := BinlogSyncerConfig{
-		ServerID:   100,
-		Flavor:     flavor,
-		Host:       *testHost,
-		Port:       port,
-		User:       "root",
-		Password:   "",
-		UseDecimal: true,
+		ServerID:             100,
+		Flavor:               flavor,
+		Host:                 *testHost,
+		Port:                 port,
+		User:                 "root",
+		Password:             "",
+		UseDecimal:           true,
+		MaxReconnectAttempts: 1,
 	}
 
 	t.b = NewBinlogSyncer(cfg)

--- a/replication/replication_test.go
+++ b/replication/replication_test.go
@@ -158,8 +158,8 @@ func (t *testSyncerSuite) testSync(c *C, s *BinlogStreamer) {
 	t.testExecute(c, "DROP TABLE IF EXISTS test_json_v2")
 
 	str = `CREATE TABLE test_json_v2 (
-			id INT,
-			c JSON,
+			id INT, 
+			c JSON, 
 			PRIMARY KEY (id)
 			) ENGINE=InnoDB`
 
@@ -236,20 +236,20 @@ func (t *testSyncerSuite) testSync(c *C, s *BinlogStreamer) {
 	// Must allow zero time.
 	t.testExecute(c, `SET sql_mode=''`)
 	str = `CREATE TABLE test_parse_time (
-			a1 DATETIME,
-			a2 DATETIME(3),
-			a3 DATETIME(6),
-			b1 TIMESTAMP,
-			b2 TIMESTAMP(3) ,
+			a1 DATETIME, 
+			a2 DATETIME(3), 
+			a3 DATETIME(6), 
+			b1 TIMESTAMP, 
+			b2 TIMESTAMP(3) , 
 			b3 TIMESTAMP(6))`
 	t.testExecute(c, str)
 
 	t.testExecute(c, `INSERT INTO test_parse_time VALUES
-		("2014-09-08 17:51:04.123456", "2014-09-08 17:51:04.123456", "2014-09-08 17:51:04.123456",
+		("2014-09-08 17:51:04.123456", "2014-09-08 17:51:04.123456", "2014-09-08 17:51:04.123456", 
 		"2014-09-08 17:51:04.123456","2014-09-08 17:51:04.123456","2014-09-08 17:51:04.123456"),
 		("0000-00-00 00:00:00.000000", "0000-00-00 00:00:00.000000", "0000-00-00 00:00:00.000000",
 		"0000-00-00 00:00:00.000000", "0000-00-00 00:00:00.000000", "0000-00-00 00:00:00.000000"),
-		("2014-09-08 17:51:04.000456", "2014-09-08 17:51:04.000456", "2014-09-08 17:51:04.000456",
+		("2014-09-08 17:51:04.000456", "2014-09-08 17:51:04.000456", "2014-09-08 17:51:04.000456", 
 		"2014-09-08 17:51:04.000456","2014-09-08 17:51:04.000456","2014-09-08 17:51:04.000456")`)
 
 	t.wg.Wait()


### PR DESCRIPTION
Refine binlog synchronization retry strategy, make it possible for user to disable retry sync or retry forever.
~After this pr the default retry strategy for BinlogSyncer is no retry (if `MaxReconnectAttempts` is not configurated and use default value zero)~
- add `DisableRetrySync` option, the default behavior for retry strategy is not changed, and user also can disable retry by setting `DisableRetrySync` to true