### PR TITLE
fix error handling during querying result rows

### DIFF
--- a/client/resp.go
+++ b/client/resp.go
@@ -317,6 +317,10 @@ func (c *Conn) readResultRows(result *Result, isBinary bool) (err error) {
 			break
 		}
 
+		if data[0] == ERR_HEADER {
+			return c.handleErrorPacket(data)
+		}
+
 		result.RowDatas = append(result.RowDatas, data)
 	}
 


### PR DESCRIPTION
When issuing a long running request with the client,  if the query get killed, `conn.Execute` will be hanging.

How to reproduce:
1. issue such request below
```
conn, _ := client.Connect("127.0.0.1:3306", "root", "", "db")
conn.Ping()
r, err := conn.Execute(`select sleep(1000), id from table`)
if err != nil {
    fmt.Println(err)
    return
}
```
2. use mysql cli to find the query id with `show processlist;` and kill the query with `kill query id;` 

the program will hang on `conn.Execute` and never return.