### PR TITLE
fix server response packet decoding for empty password duing connecti…

### DIFF
--- a/server/handshake_resp.go
+++ b/server/handshake_resp.go
@@ -143,15 +143,16 @@ func (c *Conn) readAuthData(data []byte, pos int) ([]byte, int, int, error) {
 		}
 		auth = authData
 		authLen = readBytes
-	} else {
+	} else if c.capability&CLIENT_SECURE_CONNECTION != 0 {
 		//auth length and auth
 		authLen = int(data[pos])
 		pos++
 		auth = data[pos : pos+authLen]
-		if authLen == 0 {
-			// skip the next \NUL in case the password is empty
-			pos++
-		}
+	} else {
+		authLen = bytes.IndexByte(data[pos:], 0x00)
+		auth = data[pos : pos+authLen]
+		// account for last NUL
+		authLen++
 	}
 	return auth, authLen, pos, nil
 }


### PR DESCRIPTION
…on handshake phase



Reference to the server doc on [handshake response 41](https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::HandshakeResponse41).
It's synced with [mysql current source](https://github.com/mysql/mysql-server/blob/8.0/router/src/mysql_protocol/src/handshake_packet.cc#L209-L221)

Current version seems to be based on this [doc](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_handshake_response.html#sect_protocol_connection_phase_packets_protocol_handshake_response41). 
There is a bit difference on the auth_response part. 

How to reproduce:
1. run the program below 
2. connect to the server using `mysql  --user root -p -h 127.0.0.1 --port 4000 databasename`

It'll print `dbName` as `atabasename` in `UseDB`, missing the first character

```
package main 

import (
    "fmt"
    "github.com/siddontang/go-mysql/server"
    "net"
)

type handler struct{
	empty server.EmptyHandler
}

func (h handler) UseDB(dbName string) error {
	fmt.Println(dbName)
	return h.empty.UseDB(dbName)
}

func (h handler) HandleQuery(query string) (*mysql.Result, error) {
	return h.empty.HandleQuery(query)
}

func (h handler) HandleFieldList(table string, fieldWildcard string) ([]*mysql.Field, error) {
	return h.empty.HandleFieldList(table, fieldWildcard)
}

func (h handler) HandleStmtPrepare(query string) (params int, columns int, context interface{}, err error) {
	return h.empty.HandleStmtPrepare(query)
}

func (h handler) HandleStmtExecute(context interface{}, query string, args []interface{}) (*mysql.Result, error) {
	return h.empty.HandleStmtExecute(context, query, args)
}

func (h handler) HandleStmtClose(context interface{}) error {
	return h.empty.HandleStmtClose(context)
}

func (h handler) HandleOtherCommand(cmd byte, data []byte) error {
	return h.empty.HandleOtherCommand(cmd, data)
}

func main() {
	l, _ := net.Listen("tcp", "127.0.0.1:4000")
	c, _ := l.Accept()
	conn, _ := server.NewConn(c, "root", "", handler{})
	for {
		conn.HandleCommand()
	}
}
```