### PR TITLE
handle edge condition on recoonect - repeated network errors while pa…

### DIFF
--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -761,7 +761,10 @@ func (b *BinlogSyncer) parseEvent(s *BinlogStreamer, data []byte) error {
 		prev := b.currGset.Clone()
 		err := b.currGset.Update(gtid)
 		if err == nil {
-			b.prevGset = prev
+			// right after reconnect we will see same gtid as we saw before, thus currGset will not get changed
+			if !b.currGset.Equal(prev) {
+				b.prevGset = prev
+			}
 		}
 		return err
 	}


### PR DESCRIPTION
this is a continuation of #420 
I have realized that there is a scenario when transaction will get skipped

Consider following sequence of events:
1. we have processed transaction A (TranA) and encountered a network error while reading events for next transaction (TranB).  At this point `b.prevGset` equals **TranA** and `b.currGset` equals **TranB**
2. we get to `BinlogSyncer.retrySync` and re establish binlong stream "from **TranA**". Thus first transaction we are going to see - **TranB** (which we already saw before error was encountered)

Thus we are going to enter `advanceCurrentGtidSet` with state:
 b.prevGset === **TraA**
 b.currGset === **TranB**
gtid === **TranB**

without proposed change - upon exit of this function we will have state:
 b.prevGset === **TranB**
 b.currGset === **TranB**


Which means, that if network error is encountered again, while processing same **TranB** - we will be re establishing replication stream from **TranB**, in other words first transaction delivered after such reconnect will be TranC, so **TranB will never be fully processed.**
