### PR TITLE
fix mysqldump option

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -155,6 +155,7 @@ func (c *Canal) prepareDumper() error {
 	c.dumper.SkipMasterData(c.cfg.Dump.SkipMasterData)
 	c.dumper.SetMaxAllowedPacket(c.cfg.Dump.MaxAllowedPacketMB)
 	c.dumper.SetProtocol(c.cfg.Dump.Protocol)
+	c.dumper.SetExtraOptions(c.cfg.Dump.ExtraOptions)
 	// Use hex blob for mysqldump
 	c.dumper.SetHexBlob(true)
 

--- a/canal/config.go
+++ b/canal/config.go
@@ -39,6 +39,9 @@ type DumpConfig struct {
 
 	// Set to change the default protocol to connect with
 	Protocol string `toml:"protocol"`
+
+	// Set extra options
+	ExtraOptions []string `toml:"extra_options"`
 }
 
 type Config struct {

--- a/dump/dump.go
+++ b/dump/dump.go
@@ -154,6 +154,7 @@ func (d *Dumper) Dump(w io.Writer) error {
 
 	args = append(args, "--single-transaction")
 	args = append(args, "--skip-lock-tables")
+	args = append(args, "--column-statistics=false")
 
 	// Disable uncessary data
 	args = append(args, "--compact")

--- a/dump/dump.go
+++ b/dump/dump.go
@@ -33,6 +33,8 @@ type Dumper struct {
 
 	IgnoreTables map[string][]string
 
+	ExtraOptions []string
+
 	ErrOut io.Writer
 
 	masterDataSkipped bool
@@ -59,6 +61,7 @@ func NewDumper(executionPath string, addr string, user string, password string) 
 	d.Databases = make([]string, 0, 16)
 	d.Charset = DEFAULT_CHARSET
 	d.IgnoreTables = make(map[string][]string)
+	d.ExtraOptions = make([]string, 0, 5)
 	d.masterDataSkipped = false
 
 	d.ErrOut = os.Stderr
@@ -76,6 +79,10 @@ func (d *Dumper) SetProtocol(protocol string) {
 
 func (d *Dumper) SetWhere(where string) {
 	d.Where = where
+}
+
+func (d *Dumper) SetExtraOptions(options []string) {
+	d.ExtraOptions = options
 }
 
 func (d *Dumper) SetErrOut(o io.Writer) {
@@ -154,7 +161,6 @@ func (d *Dumper) Dump(w io.Writer) error {
 
 	args = append(args, "--single-transaction")
 	args = append(args, "--skip-lock-tables")
-	args = append(args, "--column-statistics=false")
 
 	// Disable uncessary data
 	args = append(args, "--compact")
@@ -184,6 +190,10 @@ func (d *Dumper) Dump(w io.Writer) error {
 
 	if len(d.Where) != 0 {
 		args = append(args, fmt.Sprintf("--where=%s", d.Where))
+	}
+
+	if len(d.ExtraOptions) != 0 {
+		args = append(args, d.ExtraOptions...)
 	}
 
 	if len(d.Tables) == 0 && len(d.Databases) == 0 {


### PR DESCRIPTION
mysqldump client version 8.0 / MacOS
mysql server version 5.7

```
mysqldump --host=10.100.130.8 --port=3306 --user=liujilei --password=liujilei --master-data --single-transaction --skip-lock-tables --compact --skip-opt --quick --no-create-info --skip-extended-insert --skip-tz-utc --hex-blob --default-character-set=utf8  lingxi_user_account_rds profile_0 profile_1
```

error: 
```
mysqldump: Couldn't execute 'SELECT COLUMN_NAME,                       JSON_EXTRACT(HISTOGRAM, '$."number-of-buckets-specified"')                FROM information_schema.COLUMN_STATISTICS                WHERE SCHEMA_NAME = 'lingxi_user_account_rds' AND TABLE_NAME = 'profile_0';': Unknown table 'column_statistics' in information_schema (1109)
```

Becuase column-statistics default value is TRUE, I add a extra option which can be set as needed.

eg.
```
    cfg := NewDefaultConfig()
    cfg.Addr = "10.100.130.1:3306"
    cfg.User = "root"
    cfg.Password = ""
    cfg.Dump.TableDB = "users"
    cfg.Dump.Tables = []string{"profile_0", "profile_1"}
    
    // It's here !!!!!!!
    cfg.Dump.ExtraOptions = []string{"--column-statistics=false"}

    c, err := NewCanal(cfg)
    if err != nil {
        log.Printf("%s", err)
    }
    // Register a handler to handle RowsEvent
    c.SetEventHandler(&MyEventHandler{})

    // Start canal
    c.Run()
```
