### PR TITLE
fix ParseUUIDSet bug

### DIFF
--- a/mysql/mysql_gtid.go
+++ b/mysql/mysql_gtid.go
@@ -177,7 +177,7 @@ func ParseUUIDSet(str string) (*UUIDSet, error) {
 
 	// Handle interval
 	for i := 1; i < len(sep); i++ {
-		if in, err := parseInterval(sep[i]); err != nil {
+		if in, err := parseInterval(sep[1]); err != nil {
 			return nil, errors.Trace(err)
 		} else {
 			s.Intervals = append(s.Intervals, in)


### PR DESCRIPTION
sends to parseInterval full sting like "246e88bd-0288-11e8-9cee-230cd2fc765b:1-592884032", but "1-592884032" expected