### PR TITLE
fix ParseText f[i].Type has no MYSQL_TYPE_LONG

### DIFF
--- a/mysql/resultset.go
+++ b/mysql/resultset.go
@@ -42,7 +42,7 @@ func (p RowData) ParseText(f []*Field) ([]interface{}, error) {
 
 			switch f[i].Type {
 			case MYSQL_TYPE_TINY, MYSQL_TYPE_SHORT, MYSQL_TYPE_INT24,
-				MYSQL_TYPE_LONGLONG, MYSQL_TYPE_YEAR:
+				MYSQL_TYPE_LONGLONG, MYSQL_TYPE_LONG, MYSQL_TYPE_YEAR:
 				if isUnsigned {
 					data[i], err = strconv.ParseUint(string(v), 10, 64)
 				} else {


### PR DESCRIPTION
ParseText  f[i].Type case statment miss MYSQL_TYPE_LONG type