### PR TITLE
check the result of BINLOG_CHECKSUM command in maxscale as binlog server

### DIFF
--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -250,7 +250,15 @@ func (b *BinlogSyncer) registerSlave() error {
 	if r, err := b.c.Execute("SHOW GLOBAL VARIABLES LIKE 'BINLOG_CHECKSUM'"); err != nil {
 		return errors.Trace(err)
 	} else {
-		s, _ := r.GetString(0, 1)
+		// if there is a maxscale as binlog server, 
+		// the server do not support the command above,
+		// r.Resultset will be nil here,
+		// set s with "CRC32" as default value to continue.
+		s := "CRC32"
+		if r != nil && r.Resultset != nil {
+			var _ error
+			s, _ = r.GetString(0, 1)
+		}
 		if s != "" {
 			// maybe CRC32 or NONE
 


### PR DESCRIPTION
For the bug https://github.com/siddontang/go-mysql/issues/483.

I want to fix it with this pr.

However, it is not the best way to fix this bug, when the result of Executed command is empty, the variable r here is not nil, and this scene also exists in otherwhere.