### PR TITLE
go-canal: fix len(*ignoreTables) > 0

### DIFF
--- a/cmd/go-canal/main.go
+++ b/cmd/go-canal/main.go
@@ -56,7 +56,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if len(*ignoreTables) == 0 {
+	if len(*ignoreTables) > 0 {
 		subs := strings.Split(*ignoreTables, ",")
 		for _, sub := range subs {
 			if seps := strings.Split(sub, "."); len(seps) == 2 {


### PR DESCRIPTION
这里是不是应该用大于号，如果是等于0，传入的ignoreTables不就无效了