### PR TITLE
fix bug: year==0 will be resolved to the wrong value: 1900

### DIFF
--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -787,7 +787,12 @@ func (e *RowsEvent) decodeValue(data []byte, tp byte, meta uint16) (v interface{
 
 	case MYSQL_TYPE_YEAR:
 		n = 1
-		v = int(data[0]) + 1900
+		year := int(data[0])
+		if year == 0 {
+			v = year
+		} else {
+			v = year + 1900
+		}
 	case MYSQL_TYPE_ENUM:
 		l := meta & 0xFF
 		switch l {


### PR DESCRIPTION
when column type is year with value 0，will be resolved to the wrong value：1900，which is illegal in MySQL, It should be 0 instead.