### PR TITLE
Streaming of large responses without storing the whole response in memory

### DIFF
--- a/client/conn.go
+++ b/client/conn.go
@@ -33,6 +33,9 @@ type Conn struct {
 	connectionID uint32
 }
 
+// This function will be called for every row in resultset from {@see ExecuteSelectStreaming}.
+type SelectPerRowCallback func(row []FieldValue) error
+
 func getNetProto(addr string) string {
 	proto := "tcp"
 	if strings.Contains(addr, "/") {
@@ -163,6 +166,28 @@ func (c *Conn) Execute(command string, args ...interface{}) (*Result, error) {
 			return r, err
 		}
 	}
+}
+
+// ExecuteSelectStreaming will call perRowCallback for every row in resultset
+//   WITHOUT saving any row data to Result.{Values/RawPkg/RowDatas} fields.
+//
+// ExecuteSelectStreaming should be used only for SELECT queries with a large response resultset for memory preserving.
+//
+// Example:
+//
+// 		var result mysql.Result
+// 		conn.ExecuteSelectStreaming(`SELECT ... LIMIT 100500`, &result, func(row []FieldValue) (bool, error) {
+//   		// Use the row as you want.
+//   		// You must not save FieldValue.AsString() value after this callback is done. Copy it if you need.
+//   		return false, nil
+// 		})
+//
+func (c *Conn) ExecuteSelectStreaming(command string, result *Result, perRowCallback SelectPerRowCallback) error {
+	if err := c.writeCommandStr(COM_QUERY, command); err != nil {
+		return errors.Trace(err)
+	}
+
+	return c.readResultStreaming(false, result, perRowCallback)
 }
 
 func (c *Conn) Begin() error {

--- a/client/resp.go
+++ b/client/resp.go
@@ -230,6 +230,25 @@ func (c *Conn) readResult(binary bool) (*Result, error) {
 	return c.readResultset(firstPkgBuf, binary)
 }
 
+func (c *Conn) readResultStreaming(binary bool, result *Result, perRowCb SelectPerRowCallback) error {
+	firstPkgBuf, err := c.ReadPacketReuseMem(utils.ByteSliceGet(16)[:0])
+	defer utils.ByteSlicePut(firstPkgBuf)
+
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if firstPkgBuf[0] == OK_HEADER {
+		return ErrMalformPacket // Streaming allowed only for SELECT queries
+	} else if firstPkgBuf[0] == ERR_HEADER {
+		return c.handleErrorPacket(append([]byte{}, firstPkgBuf...))
+	} else if firstPkgBuf[0] == LocalInFile_HEADER {
+		return ErrMalformPacket
+	}
+
+	return c.readResultsetStreaming(firstPkgBuf, binary, result, perRowCb)
+}
+
 func (c *Conn) readResultset(data []byte, binary bool) (*Result, error) {
 	// column count
 	count, _, n := LengthEncodedInt(data)
@@ -251,6 +270,31 @@ func (c *Conn) readResultset(data []byte, binary bool) (*Result, error) {
 	}
 
 	return result, nil
+}
+
+func (c *Conn) readResultsetStreaming(data []byte, binary bool, result *Result, perRowCb SelectPerRowCallback) error {
+	columnCount, _, n := LengthEncodedInt(data)
+
+	if n-len(data) != 0 {
+		return ErrMalformPacket
+	}
+
+	if result.Resultset == nil {
+		result.Resultset = NewResultset(int(columnCount))
+	} else {
+		// Reuse memory if can
+		result.Reset(int(columnCount))
+	}
+
+	if err := c.readResultColumns(result); err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := c.readResultRowsStreaming(result, binary, perRowCb); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
 }
 
 func (c *Conn) readResultColumns(result *Result) (err error) {
@@ -334,6 +378,50 @@ func (c *Conn) readResultRows(result *Result, isBinary bool) (err error) {
 	for i := range result.Values {
 		result.Values[i], err = result.RowDatas[i].Parse(result.Fields, isBinary, result.Values[i])
 
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	return nil
+}
+
+func (c *Conn) readResultRowsStreaming(result *Result, isBinary bool, perRowCb SelectPerRowCallback) (err error) {
+	var (
+		data []byte
+		row  []FieldValue
+	)
+
+	for {
+		data, err = c.ReadPacketReuseMem(data[:0])
+		if err != nil {
+			return
+		}
+
+		// EOF Packet
+		if c.isEOFPacket(data) {
+			if c.capability&CLIENT_PROTOCOL_41 > 0 {
+				// result.Warnings = binary.LittleEndian.Uint16(data[1:])
+				// todo add strict_mode, warning will be treat as error
+				result.Status = binary.LittleEndian.Uint16(data[3:])
+				c.status = result.Status
+			}
+
+			break
+		}
+
+		if data[0] == ERR_HEADER {
+			return c.handleErrorPacket(data)
+		}
+
+		// Parse this row
+		row, err = RowData(data).Parse(result.Fields, isBinary, row)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		// Send the row to "userland" code
+		err = perRowCb(row)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/mysql/resultset.go
+++ b/mysql/resultset.go
@@ -27,9 +27,9 @@ var (
 	}
 )
 
-func NewResultset(resultsetCount int) *Resultset {
+func NewResultset(fieldsCount int) *Resultset {
 	r := resultsetPool.Get().(*Resultset)
-	r.reset(resultsetCount)
+	r.reset(fieldsCount)
 	return r
 }
 
@@ -37,7 +37,7 @@ func (r *Resultset) returnToPool() {
 	resultsetPool.Put(r)
 }
 
-func (r *Resultset) reset(count int) {
+func (r *Resultset) reset(fieldsCount int) {
 	r.RawPkg = r.RawPkg[:0]
 
 	r.Fields = r.Fields[:0]
@@ -52,14 +52,14 @@ func (r *Resultset) reset(count int) {
 		r.FieldNames = make(map[string]int)
 	}
 
-	if count == 0 {
+	if fieldsCount == 0 {
 		return
 	}
 
-	if cap(r.Fields) < count {
-		r.Fields = make([]*Field, count)
+	if cap(r.Fields) < fieldsCount {
+		r.Fields = make([]*Field, fieldsCount)
 	} else {
-		r.Fields = r.Fields[:count]
+		r.Fields = r.Fields[:fieldsCount]
 	}
 }
 

--- a/mysql/resultset.go
+++ b/mysql/resultset.go
@@ -29,7 +29,7 @@ var (
 
 func NewResultset(fieldsCount int) *Resultset {
 	r := resultsetPool.Get().(*Resultset)
-	r.reset(fieldsCount)
+	r.Reset(fieldsCount)
 	return r
 }
 
@@ -37,7 +37,7 @@ func (r *Resultset) returnToPool() {
 	resultsetPool.Put(r)
 }
 
-func (r *Resultset) reset(fieldsCount int) {
+func (r *Resultset) Reset(fieldsCount int) {
 	r.RawPkg = r.RawPkg[:0]
 
 	r.Fields = r.Fields[:0]


### PR DESCRIPTION
Standard client/Conn.Execute() stores the whole response in Resultset.RawPkg and Resultset.Values which almost doubled memory usage.

New client/Conn.ExecuteSelectStreaming() store only one row in memory at once.
